### PR TITLE
chore: add templates and trim ci triggers

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,28 @@
+---
+name: Issue
+about: Report a bug or request a change
+title: ""
+labels: []
+assignees: ""
+---
+
+## Summary
+
+## Context
+- Feature area:
+- App version/build:
+- Device/simulator:
+- OS version:
+
+## Steps to Reproduce
+1.
+2.
+3.
+
+## Expected Result
+
+## Actual Result
+
+## Screenshots or Logs
+
+## Additional Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+## Testing
+- [ ] Not run (explain why)
+- [ ] `xcodebuild test -scheme dauphin -destination 'platform=iOS Simulator,name=iPhone 15'`
+- [ ] `swift-format lint --configuration .swift-format --recursive .`
+
+## Screenshots or Recordings (UI changes)
+
+## Related Issues
+- Fixes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,22 @@
 on:
   pull_request:
+    paths:
+      - "dauphin/**"
+      - "CoursesWidget/**"
+      - "Tests/**"
+      - ".swift-format"
+      - "dauphin.xcodeproj/**"
+      - ".github/workflows/ci.yml"
   push:
     branches:
       - dev
+    paths:
+      - "dauphin/**"
+      - "CoursesWidget/**"
+      - "Tests/**"
+      - ".swift-format"
+      - "dauphin.xcodeproj/**"
+      - ".github/workflows/ci.yml"
   workflow_dispatch:
 
 concurrency:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,32 +1,37 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
-- `dauphin/` hosts the iOS app sources, grouped by feature (e.g., `ViewModels/`, `View/`, `Utilities/`).
-- `CoursesWidget/` contains the Widget extension with its own views and timeline provider.
+## Structure
+- `dauphin/` contains the iOS app sources, grouped by feature (views, view models, utilities).
+- `CoursesWidget/` is the Widget extension with its own views and timeline provider.
 - `Tests/` mirrors production modules for unit and snapshot coverage; place new tests beside the feature they validate.
-- Shared assets and configuration artifacts (e.g., `api.plist`, `StdID`) sit at the repository root—never bake secrets into code.
+- Shared assets and config artifacts (e.g., `api.plist`, `StdID`) live at the repo root. Never bake secrets into code.
 
-## Build, Test, and Development Commands
-- `xcodebuild -project dauphin.xcodeproj -scheme "dauphin" -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' clean build` compiles the main app target.
-- `xcodebuild test -scheme dauphin -destination 'platform=iOS Simulator,name=iPhone 15'` executes the XCTest suite in `Tests/`.
-- `swift-format lint --configuration .swift-format --recursive .` enforces the project’s Swift style rules; run before committing to avoid CI lint failures.
-- `xcrun simctl install booted build/Debug-iphonesimulator/dauphin.app` deploys the latest simulator build for manual QA.
+## Build, Test, and Dev Commands
+- Build app:
+  `xcodebuild -project dauphin.xcodeproj -scheme "dauphin" -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' clean build`
+- Run tests:
+  `xcodebuild test -scheme dauphin -destination 'platform=iOS Simulator,name=iPhone 15'`
+- Lint:
+  `swift-format lint --configuration .swift-format --recursive .`
+- Install to simulator:
+  `xcrun simctl install booted build/Debug-iphonesimulator/dauphin.app`
 
-## Coding Style & Naming Conventions
-- Use four-space indentation and camelCase identifiers (`courseViewModel`, not `course_vm`).
-- Decode external snake_case payloads via `CodingKeys` while exposing camelCase API on models.
-- Keep `SwiftLint` warnings at zero; annotate any rule suppression with a rationale comment.
-- Organize larger files with `// MARK:` blocks to surface logical sections in Xcode’s navigator.
+## Coding Style
+- Four-space indentation and camelCase identifiers (`courseViewModel`, not `course_vm`).
+- Decode external snake_case payloads via `CodingKeys` while exposing camelCase APIs on models.
+- Keep SwiftLint warnings at zero; justify any rule suppression with a short rationale comment.
+- Organize larger files with `// MARK:` blocks to aid navigation in Xcode.
 
-## Testing Guidelines
-- XCTest is the primary harness; suffix new files with `Tests` (e.g., `CourseViewModelTests`).
-- Favor deterministic tests—wrap async paths with expectations and sub-five-second timeouts.
-- Run `xcodebuild test` before every pull request and refresh baseline snapshots if UI output changes.
+## Testing
+- XCTest is the primary harness; name new files with a `Tests` suffix.
+- Prefer deterministic tests. Wrap async paths with expectations and sub-five-second timeouts.
+- Run `xcodebuild test` before every PR and refresh baseline snapshots when UI output changes.
 
-## Commit & Pull Request Guidelines
-- Write imperative, scoped commit messages (e.g., `fix: resolve SwiftLint warnings in CourseViewModel`). Squash transient WIP commits pre-review.
-- Pull requests must summarize behavioral changes, document test coverage, and link Jira/GitHub issues. Attach screenshots or screen recordings for UI updates.
-- Ensure CI passes (build, lint, tests) and rebase onto the latest main branch before requesting review.
+## Commit and PRs
+- Use imperative, scoped commit messages (e.g., `fix: resolve SwiftLint warnings in CourseViewModel`).
+- PRs must summarize behavior changes, document test coverage, and link Jira/GitHub issues.
+- Attach screenshots or screen recordings for UI changes.
+- Ensure CI passes (build, lint, tests) and rebase onto latest main before review.
 
-## Security & Configuration Tips
-- Secrets live in `api.plist` and load through `KeyConstants`; commit only sample values.
+## Security
+- Secrets live in `api.plist` and load through `KeyConstants`. Commit only sample values.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,44 @@
 [![.github/workflows/ci.yml](https://github.com/tkuitocc/dauphin-ios/actions/workflows/ci.yml/badge.svg?branch=dev)](https://github.com/tkuitocc/dauphin-ios/actions/workflows/ci.yml)
 
 [![pages-build-deployment](https://github.com/tkuitocc/dauphin-ios/actions/workflows/pages/pages-build-deployment/badge.svg)](https://github.com/tkuitocc/dauphin-ios/actions/workflows/pages/pages-build-deployment)
+
+## Overview
+Dauphin is an iOS app with a companion Widget extension. The codebase is organized by feature and backed by XCTest coverage.
+
+## Requirements
+- Xcode 15.4 or newer
+- iOS Simulator (iPhone 15 or newer recommended)
+- Swift 5.9+
+
+## Getting Started
+1. Clone the repo.
+2. Open `dauphin.xcodeproj` in Xcode.
+3. Select the `dauphin` scheme and build/run.
+
+## Common Commands
+```sh
+xcodebuild -project dauphin.xcodeproj -scheme "dauphin" -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.0' clean build
+```
+
+```sh
+xcodebuild test -scheme dauphin -destination 'platform=iOS Simulator,name=iPhone 15'
+```
+
+```sh
+swift-format lint --configuration .swift-format --recursive .
+```
+
+```sh
+xcrun simctl install booted build/Debug-iphonesimulator/dauphin.app
+```
+
+## Project Structure
+- `dauphin/`: iOS app sources (views, view models, utilities).
+- `CoursesWidget/`: Widget extension.
+- `Tests/`: Unit and snapshot tests.
+- Root configs: `api.plist`, `StdID` (sample values only).
+
+## Contributing
+- Keep SwiftLint warnings at zero.
+- Add or update tests for behavior changes.
+- Run lint and tests before opening a PR.


### PR DESCRIPTION
## Summary
- add issue and pull request templates
- refresh README and AGENTS guidance for onboarding
- limit CI to app-related file changes to reduce macOS runner usage

## Testing
- Not run (docs/CI changes only)

## Related Issues
- Fixes #21