### PR TITLE
fix: clean up unused values and unsafe urls

### DIFF
--- a/app/dauphin/View/CourseSchedule/Week/WeekdaysView.swift
+++ b/app/dauphin/View/CourseSchedule/Week/WeekdaysView.swift
@@ -27,7 +27,7 @@ extension WeekdaysView {
         let label = days[index]
         let weekdayValue = weekdays[index]
         let date = dateForDay(weekday: weekdayValue)
-        let isToday = weekdayValue == normalizedToday
+        let isToday = weekdayValue == currentWeekday
 
         HStack(spacing: 3) {
             Text(label).font(.system(size: 10, weight: .medium)).foregroundColor(
@@ -36,13 +36,6 @@ extension WeekdaysView {
             Text("\(date)").font(.system(size: 13, weight: isToday ? .semibold : .regular))
                 .foregroundColor(isToday ? Color.blue : Color(UIColor.label).opacity(0.7))
         }.frame(height: 20).frame(width: width, height: 20)
-    }
-}
-
-extension WeekdaysView {
-    fileprivate var normalizedToday: Int {
-        let sys = Calendar.current.component(.weekday, from: Date())
-        return sys == 1 ? 7 : (sys - 1)
     }
 }
 

--- a/app/dauphin/View/Setting/AboutUsView.swift
+++ b/app/dauphin/View/Setting/AboutUsView.swift
@@ -34,15 +34,24 @@ struct AboutUsView: View {
             }
             Section(header: Text("Third-Party Packages")) {
                 ForEach(packages, id: \.0) { package in
-                    Link(destination: URL(string: package.1)!) {
-                        Label(package.0, systemImage: "shippingbox.fill")
-                    }.accessibilityIdentifier("pkg_\(package.0)")
+                    if let url = URL(string: package.1) {
+                        Link(destination: url) { Label(package.0, systemImage: "shippingbox.fill") }
+                            .accessibilityIdentifier("pkg_\(package.0)")
+                    } else {
+                        Label(package.0, systemImage: "shippingbox.fill").accessibilityIdentifier(
+                            "pkg_\(package.0)")
+                    }
                 }
             }
             Section(header: Text("Data Sources and Resources")) {
                 ForEach(usefulLinks, id: \.0) { link in
-                    Link(destination: URL(string: link.1)!) { Label(link.0, systemImage: "globe") }
-                        .accessibilityIdentifier("link_\(link.0)")
+                    if let url = URL(string: link.1) {
+                        Link(destination: url) { Label(link.0, systemImage: "globe") }
+                            .accessibilityIdentifier("link_\(link.0)")
+                    } else {
+                        Label(link.0, systemImage: "globe").accessibilityIdentifier(
+                            "link_\(link.0)")
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- avoid force-unwrapping URLs in About Us links and keep labels for invalid URLs
- use the injected currentWeekday when highlighting the week header

Fixes #35

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
- xcodebuild -project app/dauphin.xcodeproj -scheme "dauphin" -testPlan "Models" -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" test
