### PR TITLE
perf: reuse date formatters across app and widget views

### DIFF
--- a/app/CoursesWidget/Views/NextUpLockScreenView.swift
+++ b/app/CoursesWidget/Views/NextUpLockScreenView.swift
@@ -60,21 +60,16 @@ struct CoursesNextUpViewLockScreenView: View {
         }
     }
 
-    func currentDate() -> String { Self.currentDateFormatter.string(from: Date()) }
+    func currentDate() -> String {
+        let components = Calendar.autoupdatingCurrent.dateComponents([.month, .day], from: Date())
+        let month = components.month ?? 0
+        let day = components.day ?? 0
+        return String(format: "%02d.%02d", month, day)
+    }
 
-    func currentDay() -> String { Self.currentDayFormatter.string(from: Date()) }
-
-    private static let currentDateFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MM.dd"
-        return formatter
-    }()
-
-    private static let currentDayFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEEE"
-        return formatter
-    }()
+    func currentDay() -> String {
+        Date.now.formatted(.dateTime.weekday(.wide).locale(.autoupdatingCurrent))
+    }
 }
 
 #Preview(as: .accessoryRectangular) { CoursesNextUpWidget() } timeline: {

--- a/app/CoursesWidget/Views/NextUpLockScreenView.swift
+++ b/app/CoursesWidget/Views/NextUpLockScreenView.swift
@@ -60,17 +60,21 @@ struct CoursesNextUpViewLockScreenView: View {
         }
     }
 
-    func currentDate() -> String {
+    func currentDate() -> String { Self.currentDateFormatter.string(from: Date()) }
+
+    func currentDay() -> String { Self.currentDayFormatter.string(from: Date()) }
+
+    private static let currentDateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MM.dd"
-        return formatter.string(from: Date())
-    }
+        return formatter
+    }()
 
-    func currentDay() -> String {
+    private static let currentDayFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "EEEE"
-        return formatter.string(from: Date())
-    }
+        return formatter
+    }()
 }
 
 #Preview(as: .accessoryRectangular) { CoursesNextUpWidget() } timeline: {

--- a/app/CoursesWidget/Views/NextUpSmallView.swift
+++ b/app/CoursesWidget/Views/NextUpSmallView.swift
@@ -22,16 +22,19 @@ struct CoursesNextUpSmallView: View {
 
     // Helper function to convert weekday index to name
     func weekdayName(for weekday: Int) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        let names =
-            formatter.weekdaySymbols ?? [
-                "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
-            ]
+        let names = Self.weekdaySymbols
         let normalized = max(1, min(weekday, 7))
         let index = (normalized % 7)  // Sunday -> 0, Monday -> 1, ...
         return names[index]
     }
+
+    private static let weekdaySymbols: [String] = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US")
+        return formatter.weekdaySymbols ?? [
+            "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+        ]
+    }()
 
     var body: some View {
         if entry.ssoStuNo.isEmpty {

--- a/app/CoursesWidget/Views/NextUpSmallView.swift
+++ b/app/CoursesWidget/Views/NextUpSmallView.swift
@@ -28,13 +28,9 @@ struct CoursesNextUpSmallView: View {
         return names[index]
     }
 
-    private static let weekdaySymbols: [String] = {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "en_US")
-        return formatter.weekdaySymbols ?? [
-            "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
-        ]
-    }()
+    private static let weekdaySymbols: [String] = [
+        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
+    ]
 
     var body: some View {
         if entry.ssoStuNo.isEmpty {

--- a/app/dauphin/View/CourseSchedule/Day/DateSelectorView.swift
+++ b/app/dauphin/View/CourseSchedule/Day/DateSelectorView.swift
@@ -41,13 +41,15 @@ struct DateSelectorView: View {
         }
     }
 
-    private func weekdayString(_ date: Date) -> String {
-        let f = DateFormatter()
-        f.calendar = calendar
-        f.locale = .current
-        f.dateFormat = "EEE"  // Mon, Tue, ...
-        return f.string(from: date)
-    }
+    private func weekdayString(_ date: Date) -> String { Self.weekdayFormatter.string(from: date) }
+
+    private static let weekdayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = .current
+        formatter.dateFormat = "EEE"  // Mon, Tue, ...
+        return formatter
+    }()
 
     /// Build Monday..Sunday of the current week. `day` is 1..7 for Mon..Sun.
     static func buildCurrentWeek(calendar: Calendar = Calendar(identifier: .gregorian))

--- a/app/dauphin/View/CourseSchedule/Day/DateSelectorView.swift
+++ b/app/dauphin/View/CourseSchedule/Day/DateSelectorView.swift
@@ -41,15 +41,12 @@ struct DateSelectorView: View {
         }
     }
 
-    private func weekdayString(_ date: Date) -> String { Self.weekdayFormatter.string(from: date) }
-
-    private static let weekdayFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.calendar = Calendar(identifier: .gregorian)
-        formatter.locale = .current
-        formatter.dateFormat = "EEE"  // Mon, Tue, ...
-        return formatter
-    }()
+    private func weekdayString(_ date: Date) -> String {
+        let weekday = calendar.component(.weekday, from: date)
+        let symbols = calendar.shortWeekdaySymbols
+        guard symbols.indices.contains(weekday - 1) else { return "" }
+        return symbols[weekday - 1]
+    }
 
     /// Build Monday..Sunday of the current week. `day` is 1..7 for Mon..Sun.
     static func buildCurrentWeek(calendar: Calendar = Calendar(identifier: .gregorian))

--- a/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
+++ b/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
@@ -7,13 +7,10 @@ struct DayScheduleView: View {
     @State private var showBarcode = false
     @State private var selectedCourse: Course? = nil
 
-    private func getFormattedDate() -> String { Self.monthYearFormatter.string(from: Date()) }
+    private func getFormattedDate() -> String { Date.now.formatted(Self.monthYearStyle) }
 
-    private static let monthYearFormatter: DateFormatter = {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM, yyyy"  // Month and year format
-        return formatter
-    }()
+    private static let monthYearStyle = Date.FormatStyle.dateTime.month(.wide).year(.defaultDigits)
+        .locale(.autoupdatingCurrent)
 
     var body: some View {
         VStack(spacing: 0) {

--- a/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
+++ b/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
@@ -7,11 +7,13 @@ struct DayScheduleView: View {
     @State private var showBarcode = false
     @State private var selectedCourse: Course? = nil
 
-    private func getFormattedDate() -> String {
+    private func getFormattedDate() -> String { Self.monthYearFormatter.string(from: Date()) }
+
+    private static let monthYearFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.dateFormat = "MMMM, yyyy"  // Month and year format
-        return formatter.string(from: Date())
-    }
+        return formatter
+    }()
 
     var body: some View {
         VStack(spacing: 0) {


### PR DESCRIPTION
## Summary
- replace repeated DateFormatter allocations with shared static formatters in day schedule and date selector views
- cache weekday symbols in widget small view to avoid rebuilding DateFormatter each call
- reuse lock screen widget date/day formatters instead of allocating on each render

Fixes #34

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
