### PR TITLE
refactor: align main-thread updates with structured concurrency

### DIFF
--- a/app/dauphin/View/LibSSoLoginView.swift
+++ b/app/dauphin/View/LibSSoLoginView.swift
@@ -10,12 +10,19 @@ struct LibSSOLoginView: UIViewRepresentable {
     class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
         var parent: LibSSOLoginView
         private let allowedHosts: Set<String> = ["sso.tku.edu.tw"]
+        private var evaluateTokenTask: Task<Void, Never>?
 
         init(parent: LibSSOLoginView) { self.parent = parent }
 
+        deinit { evaluateTokenTask?.cancel() }
+
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             // Web page loaded
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            evaluateTokenTask?.cancel()
+            evaluateTokenTask = Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                guard !Task.isCancelled else { return }
+
                 let javascript = """
                         try {
                             var token = getSsoLoginToken();
@@ -26,11 +33,9 @@ struct LibSSOLoginView: UIViewRepresentable {
                         }
                     """
 
-                webView.evaluateJavaScript(javascript) { (result, error) in
-                    if let error = error {
-                        LibSSOLoginView.logger.error(
-                            "JavaScript execution error: \(error.localizedDescription)")
-                    }
+                do { _ = try await webView.evaluateJavaScript(javascript) } catch {
+                    LibSSOLoginView.logger.error(
+                        "JavaScript execution error: \(error.localizedDescription)")
                 }
             }
         }

--- a/app/dauphin/View/Setting/ClearCacheView.swift
+++ b/app/dauphin/View/Setting/ClearCacheView.swift
@@ -41,7 +41,8 @@ struct ClearCacheView: View {
 
         withAnimation(.spring()) { cacheCleared = true }
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+        Task {
+            try? await Task.sleep(nanoseconds: 3_000_000_000)
             withAnimation { cacheCleared = false }
         }
     }

--- a/app/dauphin/View/Setting/ClearCacheView.swift
+++ b/app/dauphin/View/Setting/ClearCacheView.swift
@@ -11,6 +11,7 @@ struct ClearCacheView: View {
     @StateObject private var courseViewModel = CourseViewModel()
     @State private var showingClearCacheAlert = false
     @State private var cacheCleared = false
+    @State private var clearTask: Task<Void, Never>?
 
     var body: some View {
         VStack(spacing: 20) {
@@ -33,6 +34,9 @@ struct ClearCacheView: View {
             Text(
                 "This will remove all cached course data. You'll need to refresh to reload your courses."
             )
+        }.onDisappear {
+            clearTask?.cancel()
+            clearTask = nil
         }
     }
 
@@ -41,8 +45,10 @@ struct ClearCacheView: View {
 
         withAnimation(.spring()) { cacheCleared = true }
 
-        Task {
+        clearTask?.cancel()
+        clearTask = Task { @MainActor in
             try? await Task.sleep(nanoseconds: 3_000_000_000)
+            guard !Task.isCancelled else { return }
             withAnimation { cacheCleared = false }
         }
     }

--- a/app/dauphin/ViewModels/CourseViewModel.swift
+++ b/app/dauphin/ViewModels/CourseViewModel.swift
@@ -25,6 +25,7 @@ import SwiftUI
     private var monitor: NWPathMonitor
     private let monitorQueue = DispatchQueue(label: "CourseViewModel.Network")
     private var isNetworkAvailable = true
+    private var cacheMessageTask: Task<Void, Never>?
 
     private var hasPerformedInitialLoad = false
 
@@ -62,7 +63,19 @@ import SwiftUI
         startNetworkMonitor()
     }
 
-    deinit { monitor.cancel() }
+    deinit {
+        cacheMessageTask?.cancel()
+        monitor.cancel()
+    }
+
+    private func scheduleCacheMessageClear() {
+        cacheMessageTask?.cancel()
+        cacheMessageTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard !Task.isCancelled else { return }
+            self?.cacheUpdateMessage = nil
+        }
+    }
 
     private func startNetworkMonitor() {
         monitor.pathUpdateHandler = { [weak self] path in
@@ -111,6 +124,7 @@ import SwiftUI
         async
     {
         if forceRefresh { self.isRefreshing = true }
+        cacheMessageTask?.cancel()
 
         // 先載入快取顯示
         if let cached = loadCoursesFromCache(), !cached.isEmpty {
@@ -146,11 +160,7 @@ import SwiftUI
             self.isRefreshing = false
             self.cacheUpdateMessage =
                 forceRefresh ? "Refreshed successfully" : "Course data updated"
-
-            Task { @MainActor [weak self] in
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                self?.cacheUpdateMessage = nil
-            }
+            scheduleCacheMessageClear()
         } catch {
             self.isUpdatingCache = false
             self.isRefreshing = false
@@ -159,10 +169,7 @@ import SwiftUI
                 self.errorMessage = "Failed to fetch courses."
             } else if forceRefresh {
                 self.cacheUpdateMessage = "Refresh failed"
-                Task { @MainActor [weak self] in
-                    try? await Task.sleep(nanoseconds: 2_000_000_000)
-                    self?.cacheUpdateMessage = nil
-                }
+                scheduleCacheMessageClear()
             }
             Self.logger.error("Fetch error: \(error.localizedDescription)")
         }

--- a/app/dauphin/ViewModels/CourseViewModel.swift
+++ b/app/dauphin/ViewModels/CourseViewModel.swift
@@ -66,8 +66,8 @@ import SwiftUI
 
     private func startNetworkMonitor() {
         monitor.pathUpdateHandler = { [weak self] path in
-            guard let self = self else { return }
-            DispatchQueue.main.async {
+            Task { @MainActor [weak self] in
+                guard let self = self else { return }
                 self.isNetworkAvailable = (path.status == .satisfied)
                 if self.isNetworkAvailable {
                     Self.logger.debug("Network is available")
@@ -147,7 +147,8 @@ import SwiftUI
             self.cacheUpdateMessage =
                 forceRefresh ? "Refreshed successfully" : "Course data updated"
 
-            DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
                 self?.cacheUpdateMessage = nil
             }
         } catch {
@@ -158,7 +159,8 @@ import SwiftUI
                 self.errorMessage = "Failed to fetch courses."
             } else if forceRefresh {
                 self.cacheUpdateMessage = "Refresh failed"
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) { [weak self] in
+                Task { @MainActor [weak self] in
+                    try? await Task.sleep(nanoseconds: 2_000_000_000)
                     self?.cacheUpdateMessage = nil
                 }
             }


### PR DESCRIPTION
## Summary
- replace `DispatchQueue.main.async` usage in `CourseViewModel` network monitor updates with `Task { @MainActor ... }`
- replace delayed `DispatchQueue.main.asyncAfter` UI state resets with `Task.sleep`-based structured concurrency in course cache and clear-cache flows
- update SSO web token extraction to use a cancellable task and async `evaluateJavaScript` API

Part of #44

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
- xcodebuild -project app/dauphin.xcodeproj -scheme "dauphin" -testPlan "Models" -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" test
