### PR TITLE
fix: add cancellation guards for auth and event flows

### DIFF
--- a/app/dauphin/View/Other/Event/EventView.swift
+++ b/app/dauphin/View/Other/Event/EventView.swift
@@ -29,7 +29,10 @@ struct EventView: View {
                     Button {
                         addToCalendarTask?.cancel()
                         addToCalendarTask = Task { @MainActor in
-                            if await eventManager.requestWriteAccess() {
+                            let hasAccess = await eventManager.requestWriteAccess()
+                            guard !Task.isCancelled else { return }
+
+                            if hasAccess {
                                 if let ekEvent = eventManager.makeEKEvent(from: event) {
                                     editorItem = EditItem(ekEvent: ekEvent)
                                 }

--- a/app/dauphin/View/Other/Event/EventView.swift
+++ b/app/dauphin/View/Other/Event/EventView.swift
@@ -15,6 +15,7 @@ struct EventView: View {
         let ekEvent: EKEvent
     }
     @State private var editorItem: EditItem?
+    @State private var addToCalendarTask: Task<Void, Never>?
 
     var body: some View {
         List {
@@ -26,7 +27,8 @@ struct EventView: View {
                     }
                     Spacer()
                     Button {
-                        Task {
+                        addToCalendarTask?.cancel()
+                        addToCalendarTask = Task { @MainActor in
                             if await eventManager.requestWriteAccess() {
                                 if let ekEvent = eventManager.makeEKEvent(from: event) {
                                     editorItem = EditItem(ekEvent: ekEvent)
@@ -56,6 +58,9 @@ struct EventView: View {
             }
         }.task(id: term) { await viewModel.loadXMLData(withQuery: ["t": "\(term)"]) }.refreshable {
             await viewModel.loadXMLData(withQuery: ["t": "\(term)"])
+        }.onDisappear {
+            addToCalendarTask?.cancel()
+            addToCalendarTask = nil
         }
     }
 

--- a/app/dauphin/ViewModels/AuthViewModel.swift
+++ b/app/dauphin/ViewModels/AuthViewModel.swift
@@ -16,6 +16,9 @@ import os
         didSet { appGroupDefaults?.set(ssoStuNo, forKey: Constants.ssoTokenKey) }
     }
     let courseViewModel: CourseViewModel
+    private var fetchCoursesTask: Task<Void, Never>?
+
+    deinit { fetchCoursesTask?.cancel() }
 
     init(courseViewModel: CourseViewModel? = nil) {
         self.isLoggedIn = appGroupDefaults?.bool(forKey: Constants.isLoggedInKey) ?? false
@@ -42,13 +45,21 @@ import os
 
     // Fetch courses for the logged-in user
     private func fetchCourses(token: String) {
-        Task {
+        fetchCoursesTask?.cancel()
+        fetchCoursesTask = Task { @MainActor [weak self] in
+            guard let self = self else { return }
+            guard !Task.isCancelled else { return }
+            guard self.isLoggedIn, self.ssoStuNo == token else { return }
             // Initiating course fetch for authenticated user - force fetch on login
-            await courseViewModel.fetchCourses(with: token, forceRefresh: false, isFirstLogin: true)
+            await self.courseViewModel.fetchCourses(
+                with: token, forceRefresh: false, isFirstLogin: true)
         }
     }
 
     func logout() {
+        fetchCoursesTask?.cancel()
+        fetchCoursesTask = nil
+
         // Clear token and courses from App Group defaults
         appGroupDefaults?.removeObject(forKey: Constants.ssoTokenKey)
         appGroupDefaults?.removeObject(forKey: Constants.courses)

--- a/app/dauphin/ViewModels/EventViewModel.swift
+++ b/app/dauphin/ViewModels/EventViewModel.swift
@@ -24,6 +24,8 @@ import OSLog
 
             let parsed = try await Self.parseEvents(from: data, timeZone: .current)
 
+            try Task.checkCancellation()
+
             self.events = parsed
         } catch is CancellationError { Self.logger.debug("Cancelled XML load") } catch {
             Self.logger.error("Error loading XML data: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary
- add cancellable auth fetch task tracking so superseded login/logout flows cannot keep running stale course fetch work
- add cancellable add-to-calendar task tracking in EventView and cancel pending work on disappear
- add cancellation check before applying parsed XML events to avoid stale state writes

Fixes #46
Part of #44

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
- xcodebuild -project app/dauphin.xcodeproj -scheme "dauphin" -testPlan "Models" -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" test
