### PR TITLE
test: expand coverage for course data flow and widget cache

### DIFF
--- a/app/Tests/ModelsTests/CourseParserTests.swift
+++ b/app/Tests/ModelsTests/CourseParserTests.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Testing
+
+@testable import dauphin
+
+@Suite("Course Parser") struct CourseParserTests {
+    @Test("parses sorted sessions and strips html") func parsesSortedSessionsAndStripsHtml() throws
+    {
+        let json = """
+            {
+              "stuelelist": [
+                {
+                  "week": "1",
+                  "ch_cos_name": "<b>Linear Algebra</b>,extra",
+                  "teach_name": "<i>Dr. Lin</i>,x",
+                  "room": "<span>B101</span>,foo",
+                  "seat_no": "S123,foo",
+                  "note": "<p>Important</p>",
+                  "timePlase": { "sesses": ["4", "2"] }
+                }
+              ]
+            }
+            """
+
+        let parser = DefaultCourseParser(
+            htmlStrip: {
+                $0.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+            }, sessionToStart: { Date(timeIntervalSince1970: TimeInterval($0 * 60)) },
+            sessionToEnd: { Date(timeIntervalSince1970: TimeInterval($0 * 60 + 30)) })
+
+        let courses = try parser.parse(Data(json.utf8))
+        #expect(courses.count == 1)
+
+        let course = try #require(courses.first)
+        #expect(course.name == "Linear Algebra")
+        #expect(course.teacher == "Dr. Lin")
+        #expect(course.room == "B101")
+        #expect(course.stdNo == "S123")
+        #expect(course.note == "Important")
+        #expect(course.time == "2, 4")
+        #expect(course.weekday == 1)
+        #expect(course.startTime == Date(timeIntervalSince1970: 120))
+        #expect(course.endTime == Date(timeIntervalSince1970: 270))
+    }
+
+    @Test("dedupes and merges teacher names") func dedupesAndMergesTeacherNames() throws {
+        let json = """
+            {
+              "stuelelist": [
+                {
+                  "week": "2",
+                  "ch_cos_name": "Physics",
+                  "teach_name": "A",
+                  "room": "R1",
+                  "seat_no": "S1",
+                  "note": "",
+                  "timePlase": { "sesses": ["1", "2"] }
+                },
+                {
+                  "week": "2",
+                  "ch_cos_name": "Physics",
+                  "teach_name": "B",
+                  "room": "R1",
+                  "seat_no": "S1",
+                  "note": "",
+                  "timePlase": { "sesses": ["1", "2"] }
+                }
+              ]
+            }
+            """
+
+        let parser = DefaultCourseParser(
+            htmlStrip: { $0 },
+            sessionToStart: { Date(timeIntervalSince1970: TimeInterval($0 * 60)) },
+            sessionToEnd: { Date(timeIntervalSince1970: TimeInterval($0 * 60 + 30)) })
+
+        let courses = try parser.parse(Data(json.utf8))
+        #expect(courses.count == 1)
+        #expect(courses[0].teacher == "A, B")
+    }
+
+    @Test("filters invalid weekday or session rows") func filtersInvalidRows() throws {
+        let json = """
+            {
+              "stuelelist": [
+                {
+                  "week": "8",
+                  "ch_cos_name": "Ignored",
+                  "teach_name": "T",
+                  "room": "R",
+                  "seat_no": "S",
+                  "note": "",
+                  "timePlase": { "sesses": ["1"] }
+                },
+                {
+                  "week": "3",
+                  "ch_cos_name": "AlsoIgnored",
+                  "teach_name": "T",
+                  "room": "R",
+                  "seat_no": "S",
+                  "note": "",
+                  "timePlase": { "sesses": ["X"] }
+                }
+              ]
+            }
+            """
+
+        let parser = DefaultCourseParser(
+            htmlStrip: { $0 }, sessionToStart: { Date(timeIntervalSince1970: TimeInterval($0)) },
+            sessionToEnd: { Date(timeIntervalSince1970: TimeInterval($0)) })
+
+        let courses = try parser.parse(Data(json.utf8))
+        #expect(courses.isEmpty)
+    }
+}

--- a/app/Tests/ModelsTests/CourseRepositoryTests.swift
+++ b/app/Tests/ModelsTests/CourseRepositoryTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+
+@testable import dauphin
+
+private final class MockCourseAPIClient: CourseAPIClient {
+    var receivedQuery: String?
+    var nextData: Data = Data()
+
+    func fetchCoursesData(encryptedQuery: String) async throws -> Data {
+        receivedQuery = encryptedQuery
+        return nextData
+    }
+}
+
+private final class MockCourseCache: CourseCache {
+    var stored: [dauphin.Course]?
+    var didClear = false
+
+    func load() -> [dauphin.Course]? { stored }
+    func save(_ courses: [dauphin.Course]) { stored = courses }
+    func clear() {
+        didClear = true
+        stored = nil
+    }
+}
+
+private final class MockCourseParser: CourseParser {
+    var receivedData: Data?
+    var result: [dauphin.Course] = []
+
+    func parse(_ data: Data) throws -> [dauphin.Course] {
+        receivedData = data
+        return result
+    }
+}
+
+@Suite("Course Repository") struct CourseRepositoryTests {
+    @Test("throws when encryption fails") func throwsWhenEncryptionFails() async {
+        let api = MockCourseAPIClient()
+        let cache = MockCourseCache()
+        let parser = MockCourseParser()
+        let repo = DefaultCourseRepository(api: api, cache: cache, parser: parser)
+
+        await #expect(throws: URLError.self) {
+            _ = try await repo.fetchRemote(stdNo: "410000000", encrypt: { _ in nil })
+        }
+    }
+
+    @Test("passes encrypted query to API and parser output")
+    func passesEncryptedQueryAndParsesResponse() async throws {
+        let api = MockCourseAPIClient()
+        let cache = MockCourseCache()
+        let parser = MockCourseParser()
+        api.nextData = Data("raw-payload".utf8)
+
+        let expected = [
+            CourseTestSupport.makeCourse(
+                name: "N", weekday: 1, startOffsetFromNow: 0, endOffsetFromNow: 50,
+                reference: CourseTestSupport.referenceDate())
+        ]
+        parser.result = expected
+
+        let repo = DefaultCourseRepository(api: api, cache: cache, parser: parser)
+        let courses = try await repo.fetchRemote(stdNo: "410000000", encrypt: { _ in "ENC" })
+
+        #expect(api.receivedQuery == "ENC")
+        #expect(parser.receivedData == Data("raw-payload".utf8))
+        #expect(courses == expected)
+    }
+
+    @Test("delegates load/save/clear to cache") func delegatesCacheOperations() {
+        let api = MockCourseAPIClient()
+        let cache = MockCourseCache()
+        let parser = MockCourseParser()
+        let repo = DefaultCourseRepository(api: api, cache: cache, parser: parser)
+
+        let sample = [
+            CourseTestSupport.makeCourse(
+                name: "Cache", weekday: 2, startOffsetFromNow: 10, endOffsetFromNow: 70,
+                reference: CourseTestSupport.referenceDate())
+        ]
+
+        repo.saveCache(sample)
+        #expect(cache.stored == sample)
+        #expect(repo.loadCache() == sample)
+
+        repo.clearCache()
+        #expect(cache.didClear)
+        #expect(repo.loadCache() == nil)
+    }
+}

--- a/app/Tests/ModelsTests/CourseViewModelTests.swift
+++ b/app/Tests/ModelsTests/CourseViewModelTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+
+@testable import dauphin
+
+private final class MockViewModelRepository: CourseRepository {
+    var cachedCourses: [dauphin.Course]?
+    var savedCourses: [dauphin.Course]?
+    var didClear = false
+    var fetchCount = 0
+    var nextRemoteResult: Result<[dauphin.Course], Error> = .success([])
+
+    func loadCache() -> [dauphin.Course]? { cachedCourses }
+    func saveCache(_ courses: [dauphin.Course]) { savedCourses = courses }
+    func clearCache() {
+        didClear = true
+        cachedCourses = nil
+    }
+
+    func fetchRemote(stdNo _: String, encrypt _: (String) -> String?) async throws -> [dauphin
+        .Course]
+    {
+        fetchCount += 1
+        return try nextRemoteResult.get()
+    }
+}
+
+@MainActor @Suite("Course ViewModel") struct CourseViewModelTests {
+    @Test("loadCoursesFromCache updates empty state") func loadCoursesFromCacheUpdatesState() {
+        let repo = MockViewModelRepository()
+        repo.cachedCourses = []
+        let vm = CourseViewModel(repository: repo, encryptor: { _ in "ENC" })
+
+        let loaded = vm.loadCoursesFromCache()
+        #expect(loaded?.isEmpty == true)
+        #expect(vm.isCacheEmpty)
+    }
+
+    @Test("clearCache clears courses and reports message") func clearCacheResetsState() {
+        let repo = MockViewModelRepository()
+        let vm = CourseViewModel(repository: repo, encryptor: { _ in "ENC" })
+
+        vm.weekCourses = [
+            CourseTestSupport.makeCourse(
+                name: "Old", weekday: 1, startOffsetFromNow: 0, endOffsetFromNow: 30,
+                reference: CourseTestSupport.referenceDate())
+        ]
+
+        vm.clearCache()
+
+        #expect(repo.didClear)
+        #expect(vm.weekCourses.isEmpty)
+        #expect(vm.isCacheEmpty)
+        #expect(vm.errorMessage == "Cache cleared. Please refresh to load courses.")
+    }
+
+    @Test("first login fetch loads remote and saves cache")
+    func firstLoginFetchLoadsRemoteAndSavesCache() async {
+        let repo = MockViewModelRepository()
+        let remote = [
+            CourseTestSupport.makeCourse(
+                name: "Remote", weekday: 3, startOffsetFromNow: 20, endOffsetFromNow: 70,
+                reference: CourseTestSupport.referenceDate())
+        ]
+        repo.cachedCourses = []
+        repo.nextRemoteResult = .success(remote)
+
+        let vm = CourseViewModel(repository: repo, encryptor: { _ in "ENC" })
+        await vm.fetchCourses(with: "410000000", isFirstLogin: true)
+
+        #expect(repo.fetchCount == 1)
+        #expect(repo.savedCourses == remote)
+        #expect(vm.weekCourses == remote)
+        #expect(vm.errorMessage == nil)
+    }
+
+    @Test("subsequent non-forced fetch does not re-fetch")
+    func subsequentNonForcedFetchSkipsRemote() async {
+        let repo = MockViewModelRepository()
+        repo.nextRemoteResult = .success([
+            CourseTestSupport.makeCourse(
+                name: "A", weekday: 2, startOffsetFromNow: 0, endOffsetFromNow: 30,
+                reference: CourseTestSupport.referenceDate())
+        ])
+
+        let vm = CourseViewModel(repository: repo, encryptor: { _ in "ENC" })
+        await vm.fetchCourses(with: "410000000", isFirstLogin: true)
+        await vm.fetchCourses(with: "410000000")
+
+        #expect(repo.fetchCount == 1)
+    }
+}

--- a/app/Tests/ModelsTests/WidgetCacheDecodeTests.swift
+++ b/app/Tests/ModelsTests/WidgetCacheDecodeTests.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Testing
+
+@testable import dauphin
+
+@Suite("Widget Cache Decode") struct WidgetCacheDecodeTests {
+    @Test("widget-style decoder reads cache payload") func widgetStyleDecoderReadsCachePayload()
+        throws
+    {
+        let suiteName = "group.cantpr09ram.dauphin.tests.\(UUID().uuidString)"
+        let key = "courses"
+
+        let cache = DefaultsCourseCache(suiteName: suiteName, key: key)
+        let sample: [dauphin.Course] = [
+            CourseTestSupport.makeCourse(
+                name: "Widget", weekday: 4, startOffsetFromNow: 10, endOffsetFromNow: 70,
+                reference: CourseTestSupport.referenceDate())
+        ]
+
+        cache.save(sample)
+
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let data = try #require(defaults.data(forKey: key))
+        let decoded = widgetStyleDecodeCourses(data)
+        let decodedCourses = try #require(decoded)
+        #expect(decodedCourses == sample)
+    }
+
+    @Test("widget-style decoder returns nil for invalid payload")
+    func widgetStyleDecoderRejectsInvalidPayload() throws {
+        let invalid = Data("not-json".utf8)
+        #expect(widgetStyleDecodeCourses(invalid) == nil)
+    }
+
+    private func widgetStyleDecodeCourses(_ data: Data) -> [dauphin.Course]? {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try? decoder.decode([dauphin.Course].self, from: data)
+    }
+}


### PR DESCRIPTION
## Summary
- add parser-focused tests for session ordering, HTML cleanup, dedupe/teacher merge, and invalid-row filtering
- add repository tests covering encryption failure, API query wiring, parser passthrough, and cache delegation
- add view model tests for cache state handling, clear-cache behavior, first-login remote fetch, and non-forced fetch gating
- add widget cache decode tests for valid cached payload and invalid payload handling

Fixes #38

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
- xcodebuild -project app/dauphin.xcodeproj -scheme "dauphin" -testPlan "Models" -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" test
