### PR TITLE
refactor: centralize shared app constants

### DIFF
--- a/app/CoursesWidget/CoursesWidget.swift
+++ b/app/CoursesWidget/CoursesWidget.swift
@@ -11,7 +11,7 @@ import os
 
 struct Provider: TimelineProvider {
     private static let logger = Logger(
-        subsystem: "group.cantpr09ram.dauphin", category: "CoursesWidget")
+        subsystem: Constants.loggerSubsystem, category: "CoursesWidget")
 
     // MARK: - Placeholder
 
@@ -64,7 +64,7 @@ struct Provider: TimelineProvider {
     // MARK: - Helpers
 
     private func getSsoStuNo() -> String? {
-        guard let defaults = UserDefaults(suiteName: "group.cantpr09ram.dauphin") else {
+        guard let defaults = UserDefaults(suiteName: Constants.appGroupSuiteName) else {
             Provider.logger.error("App Group defaults unavailable.")
             return nil
         }
@@ -79,7 +79,7 @@ struct Provider: TimelineProvider {
     }
 
     private func loadCoursesFromCache() -> [Course]? {
-        guard let defaults = UserDefaults(suiteName: "group.cantpr09ram.dauphin") else {
+        guard let defaults = UserDefaults(suiteName: Constants.appGroupSuiteName) else {
             Provider.logger.error("App Group defaults unavailable.")
             return nil
         }

--- a/app/StdID/StdID.swift
+++ b/app/StdID/StdID.swift
@@ -9,7 +9,7 @@ struct SimpleEntry: TimelineEntry {
 }
 
 struct Provider: TimelineProvider {
-    private static let logger = Logger(subsystem: "group.cantpr09ram.dauphin", category: "StdID")
+    private static let logger = Logger(subsystem: Constants.loggerSubsystem, category: "StdID")
     func placeholder(in _: Context) -> SimpleEntry { SimpleEntry(date: .now, ssoStuNo: "") }
 
     func getSnapshot(in _: Context, completion: @escaping (SimpleEntry) -> Void) {
@@ -29,7 +29,7 @@ struct Provider: TimelineProvider {
     }
 
     private func fetchSsoStuNo() -> String {
-        let defaults = UserDefaults(suiteName: "group.cantpr09ram.dauphin")
+        let defaults = UserDefaults(suiteName: Constants.appGroupSuiteName)
         defaults?.synchronize()
         guard let value = defaults?.string(forKey: Constants.ssoTokenKey) else {
             Provider.logger.info("ssoStuNo not found, returning default value.")

--- a/app/Tests/ModelsTests/WidgetCacheDecodeTests.swift
+++ b/app/Tests/ModelsTests/WidgetCacheDecodeTests.swift
@@ -7,7 +7,7 @@ import Testing
     @Test("widget-style decoder reads cache payload") func widgetStyleDecoderReadsCachePayload()
         throws
     {
-        let suiteName = "group.cantpr09ram.dauphin.tests.\(UUID().uuidString)"
+        let suiteName = "\(Constants.appGroupSuiteName).tests.\(UUID().uuidString)"
         let key = "courses"
 
         let cache = DefaultsCourseCache(suiteName: suiteName, key: key)

--- a/app/dauphin/Utilities/Constants.swift
+++ b/app/dauphin/Utilities/Constants.swift
@@ -5,9 +5,25 @@
 //  Created by \u8b19 on 11/17/24.
 //
 
+import Foundation
+
 enum Constants {
+    static let loggerSubsystem = "group.cantpr09ram.dauphin"
+    static let appGroupSuiteName = "group.cantpr09ram.dauphin"
+
     static let ssoTokenKey = "ssoStuNo"
     static let isLoggedInKey = "isLoggedIn"
     static let loginSuccessNotification = "LoginSuccess"
     static let courses = "Courses"
+
+    static let keychainAESKey = "AES256KEY"
+    static let keychainAESIV = "AES256IV"
+
+    static let courseAPIEndpoint = "https://ilifeapi.az.tku.edu.tw/api/ilifeStuClassApi"
+    static let eventXMLAPIEndpoint = "https://ilifeapi.az.tku.edu.tw/data/xml_cal.ashx"
+    static let ssoLoginURL = "https://sso.tku.edu.tw/ilife/CoWork/AndroidSsoLogin.cshtml"
+}
+
+extension Notification.Name {
+    static let loginSuccess = Notification.Name(Constants.loginSuccessNotification)
 }

--- a/app/dauphin/Utilities/Courses/CourseAPIClient.swift
+++ b/app/dauphin/Utilities/Courses/CourseAPIClient.swift
@@ -4,7 +4,7 @@ protocol CourseAPIClient { func fetchCoursesData(encryptedQuery: String) async t
 
 struct DefaultCourseAPIClient: CourseAPIClient {
     func fetchCoursesData(encryptedQuery: String) async throws -> Data {
-        var comps = URLComponents(string: "https://ilifeapi.az.tku.edu.tw/api/ilifeStuClassApi")!
+        var comps = URLComponents(string: Constants.courseAPIEndpoint)!
         comps.queryItems = [URLQueryItem(name: "q", value: encryptedQuery)]
         guard let url = comps.url else { throw URLError(.badURL) }
         let (data, resp) = try await URLSession.shared.data(from: url)

--- a/app/dauphin/Utilities/Key/KeyConstants.swift
+++ b/app/dauphin/Utilities/Key/KeyConstants.swift
@@ -3,11 +3,11 @@ import OSLog
 
 enum KeyConstants {
     private static let logger = Logger(
-        subsystem: "group.cantpr09ram.dauphin", category: "KeyConstants")
+        subsystem: Constants.loggerSubsystem, category: "KeyConstants")
 
     static func loadAPIKeys() async throws {
-        if let key = KeychainManager.shared.get(forKey: "AES256KEY"),
-            let iv = KeychainManager.shared.get(forKey: "AES256IV"),
+        if let key = KeychainManager.shared.get(forKey: Constants.keychainAESKey),
+            let iv = KeychainManager.shared.get(forKey: Constants.keychainAESIV),
             !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
             !iv.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
         {
@@ -43,8 +43,8 @@ enum KeyConstants {
                     userInfo: [NSLocalizedDescriptionKey: "AES key or IV is empty."])
             }
 
-            KeychainManager.shared.save(key, forKey: "AES256KEY")
-            KeychainManager.shared.save(iv, forKey: "AES256IV")
+            KeychainManager.shared.save(key, forKey: Constants.keychainAESKey)
+            KeychainManager.shared.save(iv, forKey: Constants.keychainAESIV)
             logger.info("API keys successfully saved to Keychain")
         } catch {
             logger.error("Failed to load or decode 'api.plist': \(error.localizedDescription)")

--- a/app/dauphin/View/LibSSoLoginView.swift
+++ b/app/dauphin/View/LibSSoLoginView.swift
@@ -4,7 +4,7 @@ import WebKit
 
 struct LibSSOLoginView: UIViewRepresentable {
     private static let logger = Logger(
-        subsystem: "group.cantpr09ram.dauphin", category: "LibSSOLogin")
+        subsystem: Constants.loggerSubsystem, category: "LibSSOLogin")
     @ObservedObject var viewModel: AuthViewModel
 
     class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
@@ -94,7 +94,7 @@ struct LibSSOLoginView: UIViewRepresentable {
         let webView = WKWebView(frame: .zero, configuration: config)
         webView.navigationDelegate = context.coordinator
 
-        if let url = URL(string: "https://sso.tku.edu.tw/ilife/CoWork/AndroidSsoLogin.cshtml") {
+        if let url = URL(string: Constants.ssoLoginURL) {
             let request = URLRequest(url: url)
             webView.load(request)
         }

--- a/app/dauphin/ViewModels/AuthViewModel.swift
+++ b/app/dauphin/ViewModels/AuthViewModel.swift
@@ -6,8 +6,8 @@ import os
 
 @MainActor final class AuthViewModel: ObservableObject {
     private static let logger = Logger(
-        subsystem: "group.cantpr09ram.dauphin", category: "AuthViewModel")
-    private let appGroupDefaults = UserDefaults(suiteName: "group.cantpr09ram.dauphin")
+        subsystem: Constants.loggerSubsystem, category: "AuthViewModel")
+    private let appGroupDefaults = UserDefaults(suiteName: Constants.appGroupSuiteName)
 
     @Published var isLoggedIn: Bool {
         didSet { appGroupDefaults?.set(isLoggedIn, forKey: Constants.isLoggedInKey) }

--- a/app/dauphin/ViewModels/CourseViewModel.swift
+++ b/app/dauphin/ViewModels/CourseViewModel.swift
@@ -6,7 +6,7 @@ import SwiftUI
 @MainActor final class CourseViewModel: ObservableObject {
 
     private static let logger = Logger(
-        subsystem: "group.cantpr09ram.dauphin", category: "CourseViewModel")
+        subsystem: Constants.loggerSubsystem, category: "CourseViewModel")
 
     // 對外狀態：維持不變
     @Published var weekCourses: [Course] = []
@@ -36,7 +36,7 @@ import SwiftUI
     ) {
         // Cache 與 Parser 預設注入
         let cache = DefaultsCourseCache(
-            suiteName: "group.cantpr09ram.dauphin", key: Constants.courses)
+            suiteName: Constants.appGroupSuiteName, key: Constants.courses)
         let parser = DefaultCourseParser(
             htmlStrip: { text in
                 text.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
@@ -47,8 +47,8 @@ import SwiftUI
 
         if let enc = encryptor {
             self.encryptor = enc
-        } else if let key = KeychainManager.shared.get(forKey: "AES256KEY"),
-            let iv = KeychainManager.shared.get(forKey: "AES256IV")
+        } else if let key = KeychainManager.shared.get(forKey: Constants.keychainAESKey),
+            let iv = KeychainManager.shared.get(forKey: Constants.keychainAESIV)
         {
             let helper = CustomAES256Helper(key: key, iv: iv)
             self.encryptor = { helper.encrypt(data: $0) }

--- a/app/dauphin/ViewModels/EventViewModel.swift
+++ b/app/dauphin/ViewModels/EventViewModel.swift
@@ -3,11 +3,11 @@ import OSLog
 
 @MainActor final class EventViewModel: ObservableObject {
     private static let logger = Logger(
-        subsystem: "group.cantpr09ram.dauphin", category: "EventViewModel")
+        subsystem: Constants.loggerSubsystem, category: "EventViewModel")
     @Published private(set) var events: [CalendarEvent] = []
 
     func loadXMLData(withQuery query: [String: String]) async {
-        var components = URLComponents(string: "https://ilifeapi.az.tku.edu.tw/data/xml_cal.ashx")
+        var components = URLComponents(string: Constants.eventXMLAPIEndpoint)
         components?.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) }
 
         guard let url = components?.url else {

--- a/app/dauphin/dauphinApp.swift
+++ b/app/dauphin/dauphinApp.swift
@@ -2,7 +2,7 @@ import OSLog
 import SwiftUI
 
 @main struct MyApp: App {
-    private static let logger = Logger(subsystem: "group.cantpr09ram.dauphin", category: "App")
+    private static let logger = Logger(subsystem: Constants.loggerSubsystem, category: "App")
     @State private var isLoaded = false
     @State private var errorMessage: String?
 


### PR DESCRIPTION
## Summary
- centralize repeated app constants in `Constants` for logger subsystem, app group suite name, keychain keys, and endpoint URLs
- replace duplicated literals across app and widget targets to use shared constants
- align widget cache test suite naming with shared app group constant

Fixes  (#47)

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
- xcodebuild -project app/dauphin.xcodeproj -scheme "dauphin" -testPlan "Models" -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" test
