### PR TITLE
chore: enable and satisfy strict concurrency diagnostics

### DIFF
--- a/app/Tests/ModelsTests/CourseRepositoryTests.swift
+++ b/app/Tests/ModelsTests/CourseRepositoryTests.swift
@@ -7,7 +7,7 @@ private final class MockCourseAPIClient: CourseAPIClient {
     var receivedQuery: String?
     var nextData: Data = Data()
 
-    func fetchCoursesData(encryptedQuery: String) async throws -> Data {
+    @MainActor func fetchCoursesData(encryptedQuery: String) async throws -> Data {
         receivedQuery = encryptedQuery
         return nextData
     }
@@ -35,7 +35,7 @@ private final class MockCourseParser: CourseParser {
     }
 }
 
-@Suite("Course Repository") struct CourseRepositoryTests {
+@MainActor @Suite("Course Repository") struct CourseRepositoryTests {
     @Test("throws when encryption fails") func throwsWhenEncryptionFails() async {
         let api = MockCourseAPIClient()
         let cache = MockCourseCache()

--- a/app/Tests/ModelsTests/CourseRepositoryTests.swift
+++ b/app/Tests/ModelsTests/CourseRepositoryTests.swift
@@ -6,8 +6,10 @@ import Testing
 private final class MockCourseAPIClient: CourseAPIClient {
     var receivedQuery: String?
     var nextData: Data = Data()
+    var nextError: Error?
 
-    @MainActor func fetchCoursesData(encryptedQuery: String) async throws -> Data {
+    @CourseDataActor func fetchCoursesData(encryptedQuery: String) async throws -> Data {
+        if let nextError { throw nextError }
         receivedQuery = encryptedQuery
         return nextData
     }
@@ -36,14 +38,15 @@ private final class MockCourseParser: CourseParser {
 }
 
 @MainActor @Suite("Course Repository") struct CourseRepositoryTests {
-    @Test("throws when encryption fails") func throwsWhenEncryptionFails() async {
+    @Test("propagates API errors") func propagatesAPIErrors() async {
         let api = MockCourseAPIClient()
         let cache = MockCourseCache()
         let parser = MockCourseParser()
         let repo = DefaultCourseRepository(api: api, cache: cache, parser: parser)
+        api.nextError = URLError(.timedOut)
 
         await #expect(throws: URLError.self) {
-            _ = try await repo.fetchRemote(stdNo: "410000000", encrypt: { _ in nil })
+            _ = try await repo.fetchRemote(encryptedQuery: "ENC")
         }
     }
 
@@ -62,7 +65,7 @@ private final class MockCourseParser: CourseParser {
         parser.result = expected
 
         let repo = DefaultCourseRepository(api: api, cache: cache, parser: parser)
-        let courses = try await repo.fetchRemote(stdNo: "410000000", encrypt: { _ in "ENC" })
+        let courses = try await repo.fetchRemote(encryptedQuery: "ENC")
 
         #expect(api.receivedQuery == "ENC")
         #expect(parser.receivedData == Data("raw-payload".utf8))

--- a/app/Tests/ModelsTests/CourseViewModelTests.swift
+++ b/app/Tests/ModelsTests/CourseViewModelTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import dauphin
 
-private final class MockViewModelRepository: CourseRepository {
+@MainActor private final class MockViewModelRepository: CourseRepository {
     var cachedCourses: [dauphin.Course]?
     var savedCourses: [dauphin.Course]?
     var didClear = false

--- a/app/Tests/ModelsTests/CourseViewModelTests.swift
+++ b/app/Tests/ModelsTests/CourseViewModelTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import dauphin
 
-@MainActor private final class MockViewModelRepository: CourseRepository {
+private final class MockViewModelRepository: CourseRepository, @unchecked Sendable {
     var cachedCourses: [dauphin.Course]?
     var savedCourses: [dauphin.Course]?
     var didClear = false
@@ -17,9 +17,7 @@ import Testing
         cachedCourses = nil
     }
 
-    func fetchRemote(stdNo _: String, encrypt _: (String) -> String?) async throws -> [dauphin
-        .Course]
-    {
+    @CourseDataActor func fetchRemote(encryptedQuery _: String) async throws -> [dauphin.Course] {
         fetchCount += 1
         return try nextRemoteResult.get()
     }

--- a/app/dauphin.xcodeproj/project.pbxproj
+++ b/app/dauphin.xcodeproj/project.pbxproj
@@ -1261,6 +1261,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Debug;
 		};
@@ -1320,6 +1321,7 @@
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_STRICT_CONCURRENCY = complete;
 			};
 			name = Release;
 		};

--- a/app/dauphin/Utilities/Courses/CourseAPIClient.swift
+++ b/app/dauphin/Utilities/Courses/CourseAPIClient.swift
@@ -1,9 +1,11 @@
 import Foundation
 
-protocol CourseAPIClient { func fetchCoursesData(encryptedQuery: String) async throws -> Data }
+protocol CourseAPIClient {
+    @MainActor func fetchCoursesData(encryptedQuery: String) async throws -> Data
+}
 
 struct DefaultCourseAPIClient: CourseAPIClient {
-    func fetchCoursesData(encryptedQuery: String) async throws -> Data {
+    @MainActor func fetchCoursesData(encryptedQuery: String) async throws -> Data {
         var comps = URLComponents(string: Constants.courseAPIEndpoint)!
         comps.queryItems = [URLQueryItem(name: "q", value: encryptedQuery)]
         guard let url = comps.url else { throw URLError(.badURL) }

--- a/app/dauphin/Utilities/Courses/CourseAPIClient.swift
+++ b/app/dauphin/Utilities/Courses/CourseAPIClient.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 protocol CourseAPIClient {
-    @MainActor func fetchCoursesData(encryptedQuery: String) async throws -> Data
+    @CourseDataActor func fetchCoursesData(encryptedQuery: String) async throws -> Data
 }
 
 struct DefaultCourseAPIClient: CourseAPIClient {
-    @MainActor func fetchCoursesData(encryptedQuery: String) async throws -> Data {
+    @CourseDataActor func fetchCoursesData(encryptedQuery: String) async throws -> Data {
         var comps = URLComponents(string: Constants.courseAPIEndpoint)!
         comps.queryItems = [URLQueryItem(name: "q", value: encryptedQuery)]
         guard let url = comps.url else { throw URLError(.badURL) }

--- a/app/dauphin/Utilities/Courses/CourseRepository.swift
+++ b/app/dauphin/Utilities/Courses/CourseRepository.swift
@@ -4,7 +4,8 @@ protocol CourseRepository {
     func loadCache() -> [Course]?
     func saveCache(_ courses: [Course])
     func clearCache()
-    func fetchRemote(stdNo: String, encrypt: (String) -> String?) async throws -> [Course]
+    @MainActor func fetchRemote(stdNo: String, encrypt: (String) -> String?) async throws
+        -> [Course]
 }
 
 struct DefaultCourseRepository: CourseRepository {
@@ -17,7 +18,9 @@ struct DefaultCourseRepository: CourseRepository {
     func clearCache() { cache.clear() }
 
     // CourseRepository.swift
-    func fetchRemote(stdNo: String, encrypt: (String) -> String?) async throws -> [Course] {
+    @MainActor func fetchRemote(stdNo: String, encrypt: (String) -> String?) async throws
+        -> [Course]
+    {
         guard let enc = encrypt("20220901200540356," + stdNo) else {
             throw URLError(.cannotParseResponse)
         }

--- a/app/dauphin/Utilities/Courses/CourseRepository.swift
+++ b/app/dauphin/Utilities/Courses/CourseRepository.swift
@@ -1,14 +1,15 @@
 import Foundation
 
-protocol CourseRepository {
+@globalActor actor CourseDataActor { static let shared = CourseDataActor() }
+
+protocol CourseRepository: Sendable {
     func loadCache() -> [Course]?
     func saveCache(_ courses: [Course])
     func clearCache()
-    @MainActor func fetchRemote(stdNo: String, encrypt: (String) -> String?) async throws
-        -> [Course]
+    @CourseDataActor func fetchRemote(encryptedQuery: String) async throws -> [Course]
 }
 
-struct DefaultCourseRepository: CourseRepository {
+struct DefaultCourseRepository: CourseRepository, @unchecked Sendable {
     let api: CourseAPIClient
     let cache: CourseCache
     let parser: CourseParser
@@ -17,14 +18,8 @@ struct DefaultCourseRepository: CourseRepository {
     func saveCache(_ courses: [Course]) { cache.save(courses) }
     func clearCache() { cache.clear() }
 
-    // CourseRepository.swift
-    @MainActor func fetchRemote(stdNo: String, encrypt: (String) -> String?) async throws
-        -> [Course]
-    {
-        guard let enc = encrypt("20220901200540356," + stdNo) else {
-            throw URLError(.cannotParseResponse)
-        }
-        let data = try await api.fetchCoursesData(encryptedQuery: enc)
+    @CourseDataActor func fetchRemote(encryptedQuery: String) async throws -> [Course] {
+        let data = try await api.fetchCoursesData(encryptedQuery: encryptedQuery)
         return try parser.parse(data)
     }
 }

--- a/app/dauphin/Utilities/Key/KeyConstants.swift
+++ b/app/dauphin/Utilities/Key/KeyConstants.swift
@@ -5,7 +5,7 @@ enum KeyConstants {
     private static let logger = Logger(
         subsystem: Constants.loggerSubsystem, category: "KeyConstants")
 
-    static func loadAPIKeys() async throws {
+    @MainActor static func loadAPIKeys() async throws {
         if let key = KeychainManager.shared.get(forKey: Constants.keychainAESKey),
             let iv = KeychainManager.shared.get(forKey: Constants.keychainAESIV),
             !key.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,

--- a/app/dauphin/Utilities/Key/KeychainManager.swift
+++ b/app/dauphin/Utilities/Key/KeychainManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import KeychainSwift
 
-struct KeychainManager {
+final class KeychainManager: @unchecked Sendable {
     static let shared = KeychainManager()
     private let keychain: KeychainSwift
 

--- a/app/dauphin/Utilities/Key/KeychainManager.swift
+++ b/app/dauphin/Utilities/Key/KeychainManager.swift
@@ -8,7 +8,7 @@
 import Foundation
 import KeychainSwift
 
-final class KeychainManager: @unchecked Sendable {
+@MainActor final class KeychainManager {
     static let shared = KeychainManager()
     private let keychain: KeychainSwift
 

--- a/app/dauphin/View/LibSSoLoginView.swift
+++ b/app/dauphin/View/LibSSoLoginView.swift
@@ -58,7 +58,7 @@ struct LibSSOLoginView: UIViewRepresentable {
 
         func webView(
             _ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction,
-            decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
         ) {
             guard let url = navigationAction.request.url else {
                 decisionHandler(.cancel)

--- a/app/dauphin/View/Other/Map/LandMarkView.swift
+++ b/app/dauphin/View/Other/Map/LandMarkView.swift
@@ -1,4 +1,4 @@
-import MapKit
+@preconcurrency import MapKit
 import SwiftUI
 
 struct LandmarkView: View {

--- a/app/dauphin/View/Other/Map/MapView.swift
+++ b/app/dauphin/View/Other/Map/MapView.swift
@@ -1,4 +1,4 @@
-import MapKit
+@preconcurrency import MapKit
 import SwiftUI
 
 struct MapView: View {

--- a/app/dauphin/ViewModels/CourseViewModel.swift
+++ b/app/dauphin/ViewModels/CourseViewModel.swift
@@ -151,7 +151,10 @@ import SwiftUI
         self.cacheUpdateMessage = "Updating course data..."
 
         do {
-            let courses = try await repo.fetchRemote(stdNo: stdNo, encrypt: encryptor)
+            guard let encryptedQuery = encryptor("20220901200540356," + stdNo) else {
+                throw URLError(.cannotParseResponse)
+            }
+            let courses = try await repo.fetchRemote(encryptedQuery: encryptedQuery)
             saveCoursesToCache(courses: courses)
             self.weekCourses = courses
             self.isCacheEmpty = courses.isEmpty


### PR DESCRIPTION
## Summary
- enable strict Swift concurrency diagnostics at project build settings level
- resolve surfaced concurrency warnings by tightening actor annotations and callback signatures
- align map imports and keychain singleton declarations with strict-concurrency expectations

Fixes #47
Part of #44

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
- xcodebuild -project app/dauphin.xcodeproj -scheme "dauphin" -testPlan "Models" -destination "platform=iOS Simulator,name=iPhone 17,OS=26.2" test
