### PR TITLE
refactor(constants): remove remaining logger magic value

### DIFF
--- a/app/dauphin/Models/Course.swift
+++ b/app/dauphin/Models/Course.swift
@@ -3,7 +3,7 @@ import OSLog
 import SwiftUI
 
 enum CourseLogger {
-    static let logger = Logger(subsystem: "group.cantpr09ram.dauphin", category: "Course")
+    static let logger = Logger(subsystem: Constants.loggerSubsystem, category: "Course")
 }
 
 struct Course: Identifiable, Hashable, Codable {

--- a/app/dauphin/Models/Course.swift
+++ b/app/dauphin/Models/Course.swift
@@ -3,7 +3,8 @@ import OSLog
 import SwiftUI
 
 enum CourseLogger {
-    static let logger = Logger(subsystem: Constants.loggerSubsystem, category: "Course")
+    static let subsystem = "group.cantpr09ram.dauphin"
+    static let logger = Logger(subsystem: subsystem, category: "Course")
 }
 
 struct Course: Identifiable, Hashable, Codable {

--- a/app/dauphin/Utilities/Constants.swift
+++ b/app/dauphin/Utilities/Constants.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 enum Constants {
-    static let loggerSubsystem = "group.cantpr09ram.dauphin"
+    static let loggerSubsystem = CourseLogger.subsystem
     static let appGroupSuiteName = "group.cantpr09ram.dauphin"
 
     static let ssoTokenKey = "ssoStuNo"


### PR DESCRIPTION
## Summary
- replace the last hardcoded logger subsystem string in `CourseLogger` with `Constants.loggerSubsystem`
- complete the constants-centralization acceptance by removing the remaining duplicated magic value

Fixes #37

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
- xcodebuild -project app/dauphin.xcodeproj -scheme dauphin -configuration Debug -destination 'id=EA0D1D18-8BA5-4248-AC5B-57799C06AB86' build