### PR TITLE
refactor(course-vm): split crypto and network services

### DIFF
--- a/app/Tests/ModelsTests/CourseViewModelTests.swift
+++ b/app/Tests/ModelsTests/CourseViewModelTests.swift
@@ -23,13 +23,13 @@ private final class MockViewModelRepository: CourseRepository, @unchecked Sendab
     }
 }
 
-private struct MockCourseQueryEncryptor: CourseQueryEncrypting {
+private struct MockCourseQueryEncryptor: CourseQueryEncryptor {
     var nextValue: String?
 
     @MainActor func encryptedQuery(stdNo _: String) -> String? { nextValue }
 }
 
-private final class MockNetworkStatusProvider: NetworkStatusProviding, @unchecked Sendable {
+private final class MockNetworkStatusProvider: NetworkStatusProvider, @unchecked Sendable {
     var isNetworkAvailable: Bool
     private var onUpdate: (@Sendable (Bool) -> Void)?
 

--- a/app/Tests/ModelsTests/CourseViewModelTests.swift
+++ b/app/Tests/ModelsTests/CourseViewModelTests.swift
@@ -23,11 +23,40 @@ private final class MockViewModelRepository: CourseRepository, @unchecked Sendab
     }
 }
 
+private struct MockCourseQueryEncryptor: CourseQueryEncrypting {
+    var nextValue: String?
+
+    @MainActor func encryptedQuery(stdNo _: String) -> String? { nextValue }
+}
+
+private final class MockNetworkStatusProvider: NetworkStatusProviding, @unchecked Sendable {
+    var isNetworkAvailable: Bool
+    private var onUpdate: (@Sendable (Bool) -> Void)?
+
+    init(isNetworkAvailable: Bool = true) { self.isNetworkAvailable = isNetworkAvailable }
+
+    func startMonitoring(_ onUpdate: @escaping @Sendable (Bool) -> Void) {
+        self.onUpdate = onUpdate
+    }
+    func stopMonitoring() { onUpdate = nil }
+}
+
 @MainActor @Suite("Course ViewModel") struct CourseViewModelTests {
+    private func makeViewModel(
+        repository: MockViewModelRepository, encryptedQuery: String? = "ENC",
+        isNetworkAvailable: Bool = true
+    ) -> CourseViewModel {
+        CourseViewModel(
+            repository: repository,
+            queryEncryptor: MockCourseQueryEncryptor(nextValue: encryptedQuery),
+            networkStatusProvider: MockNetworkStatusProvider(isNetworkAvailable: isNetworkAvailable)
+        )
+    }
+
     @Test("loadCoursesFromCache updates empty state") func loadCoursesFromCacheUpdatesState() {
         let repo = MockViewModelRepository()
         repo.cachedCourses = []
-        let vm = CourseViewModel(repository: repo, encryptor: { _ in "ENC" })
+        let vm = makeViewModel(repository: repo)
 
         let loaded = vm.loadCoursesFromCache()
         #expect(loaded?.isEmpty == true)
@@ -36,7 +65,7 @@ private final class MockViewModelRepository: CourseRepository, @unchecked Sendab
 
     @Test("clearCache clears courses and reports message") func clearCacheResetsState() {
         let repo = MockViewModelRepository()
-        let vm = CourseViewModel(repository: repo, encryptor: { _ in "ENC" })
+        let vm = makeViewModel(repository: repo)
 
         vm.weekCourses = [
             CourseTestSupport.makeCourse(
@@ -63,7 +92,7 @@ private final class MockViewModelRepository: CourseRepository, @unchecked Sendab
         repo.cachedCourses = []
         repo.nextRemoteResult = .success(remote)
 
-        let vm = CourseViewModel(repository: repo, encryptor: { _ in "ENC" })
+        let vm = makeViewModel(repository: repo)
         await vm.fetchCourses(with: "410000000", isFirstLogin: true)
 
         #expect(repo.fetchCount == 1)
@@ -81,10 +110,32 @@ private final class MockViewModelRepository: CourseRepository, @unchecked Sendab
                 reference: CourseTestSupport.referenceDate())
         ])
 
-        let vm = CourseViewModel(repository: repo, encryptor: { _ in "ENC" })
+        let vm = makeViewModel(repository: repo)
         await vm.fetchCourses(with: "410000000", isFirstLogin: true)
         await vm.fetchCourses(with: "410000000")
 
         #expect(repo.fetchCount == 1)
+    }
+
+    @Test("offline state skips remote fetch and reports cache error")
+    func offlineStateSkipsRemoteFetch() async {
+        let repo = MockViewModelRepository()
+        let vm = makeViewModel(repository: repo, isNetworkAvailable: false)
+
+        await vm.fetchCourses(with: "410000000", isFirstLogin: true)
+
+        #expect(repo.fetchCount == 0)
+        #expect(vm.errorMessage == "No internet connection and no cached data available.")
+    }
+
+    @Test("encryption failure skips remote fetch and reports error")
+    func encryptionFailureSkipsRemoteFetch() async {
+        let repo = MockViewModelRepository()
+        let vm = makeViewModel(repository: repo, encryptedQuery: nil)
+
+        await vm.fetchCourses(with: "410000000", isFirstLogin: true)
+
+        #expect(repo.fetchCount == 0)
+        #expect(vm.errorMessage == "Failed to fetch courses.")
     }
 }

--- a/app/dauphin/Utilities/Courses/CourseQueryEncryptor.swift
+++ b/app/dauphin/Utilities/Courses/CourseQueryEncryptor.swift
@@ -1,12 +1,19 @@
 import Foundation
+import OSLog
 
-protocol CourseQueryEncrypting { @MainActor func encryptedQuery(stdNo: String) -> String? }
+protocol CourseQueryEncryptor { @MainActor func encryptedQuery(stdNo: String) -> String? }
 
-struct DefaultCourseQueryEncryptor: CourseQueryEncrypting {
+struct DefaultCourseQueryEncryptor: CourseQueryEncryptor {
+    private static let logger = Logger(
+        subsystem: Constants.loggerSubsystem, category: "CourseQueryEncryptor")
+
     @MainActor func encryptedQuery(stdNo: String) -> String? {
         guard let key = KeychainManager.shared.get(forKey: Constants.keychainAESKey),
             let iv = KeychainManager.shared.get(forKey: Constants.keychainAESIV)
-        else { return nil }
+        else {
+            Self.logger.error("Missing AES key or IV in keychain")
+            return nil
+        }
 
         let helper = CustomAES256Helper(key: key, iv: iv)
         return helper.encrypt(data: "20220901200540356," + stdNo)

--- a/app/dauphin/Utilities/Courses/CourseQueryEncryptor.swift
+++ b/app/dauphin/Utilities/Courses/CourseQueryEncryptor.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+protocol CourseQueryEncrypting { @MainActor func encryptedQuery(stdNo: String) -> String? }
+
+struct DefaultCourseQueryEncryptor: CourseQueryEncrypting {
+    @MainActor func encryptedQuery(stdNo: String) -> String? {
+        guard let key = KeychainManager.shared.get(forKey: Constants.keychainAESKey),
+            let iv = KeychainManager.shared.get(forKey: Constants.keychainAESIV)
+        else { return nil }
+
+        let helper = CustomAES256Helper(key: key, iv: iv)
+        return helper.encrypt(data: "20220901200540356," + stdNo)
+    }
+}

--- a/app/dauphin/Utilities/Courses/NetworkStatusProvider.swift
+++ b/app/dauphin/Utilities/Courses/NetworkStatusProvider.swift
@@ -1,27 +1,40 @@
 import Foundation
 import Network
 
-protocol NetworkStatusProviding: AnyObject, Sendable {
+protocol NetworkStatusProvider: AnyObject, Sendable {
     var isNetworkAvailable: Bool { get }
     func startMonitoring(_ onUpdate: @escaping @Sendable (Bool) -> Void)
     func stopMonitoring()
 }
 
-final class DefaultNetworkStatusProvider: NetworkStatusProviding, @unchecked Sendable {
+final class DefaultNetworkStatusProvider: NetworkStatusProvider, @unchecked Sendable {
     private let monitor: NWPathMonitor
     private let queue = DispatchQueue(label: "CourseViewModel.Network")
-    private(set) var isNetworkAvailable: Bool = true
+    private let lock = NSLock()
+    private var _isNetworkAvailable: Bool = true
+
+    var isNetworkAvailable: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return _isNetworkAvailable
+    }
 
     init(monitor: NWPathMonitor = NWPathMonitor()) { self.monitor = monitor }
 
     func startMonitoring(_ onUpdate: @escaping @Sendable (Bool) -> Void) {
         monitor.pathUpdateHandler = { [weak self] path in
             let available = path.status == .satisfied
-            self?.isNetworkAvailable = available
+            self?.setNetworkAvailable(available)
             onUpdate(available)
         }
         monitor.start(queue: queue)
     }
 
     func stopMonitoring() { monitor.cancel() }
+
+    private func setNetworkAvailable(_ available: Bool) {
+        lock.lock()
+        _isNetworkAvailable = available
+        lock.unlock()
+    }
 }

--- a/app/dauphin/Utilities/Courses/NetworkStatusProvider.swift
+++ b/app/dauphin/Utilities/Courses/NetworkStatusProvider.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Network
+
+protocol NetworkStatusProviding: AnyObject, Sendable {
+    var isNetworkAvailable: Bool { get }
+    func startMonitoring(_ onUpdate: @escaping @Sendable (Bool) -> Void)
+    func stopMonitoring()
+}
+
+final class DefaultNetworkStatusProvider: NetworkStatusProviding, @unchecked Sendable {
+    private let monitor: NWPathMonitor
+    private let queue = DispatchQueue(label: "CourseViewModel.Network")
+    private(set) var isNetworkAvailable: Bool = true
+
+    init(monitor: NWPathMonitor = NWPathMonitor()) { self.monitor = monitor }
+
+    func startMonitoring(_ onUpdate: @escaping @Sendable (Bool) -> Void) {
+        monitor.pathUpdateHandler = { [weak self] path in
+            let available = path.status == .satisfied
+            self?.isNetworkAvailable = available
+            onUpdate(available)
+        }
+        monitor.start(queue: queue)
+    }
+
+    func stopMonitoring() { monitor.cancel() }
+}

--- a/app/dauphin/ViewModels/CourseViewModel.swift
+++ b/app/dauphin/ViewModels/CourseViewModel.swift
@@ -1,5 +1,4 @@
 import Combine
-import Network
 import OSLog
 import SwiftUI
 
@@ -19,11 +18,10 @@ import SwiftUI
     // 內部依賴
     private let repo: CourseRepository
     private let nextUp: NextUpService
-    private let encryptor: (String) -> String?
+    private let queryEncryptor: CourseQueryEncrypting
+    private let networkStatusProvider: NetworkStatusProviding
 
     // 網路狀態（維持原行為）
-    private var monitor: NWPathMonitor
-    private let monitorQueue = DispatchQueue(label: "CourseViewModel.Network")
     private var isNetworkAvailable = true
     private var cacheMessageTask: Task<Void, Never>?
 
@@ -32,7 +30,8 @@ import SwiftUI
     // 預設建構符合舊使用方式（不改外部）
     init(
         repository: CourseRepository? = nil, nextUpService: NextUpService = DefaultNextUpService(),
-        encryptor: ((String) -> String?)? = nil
+        queryEncryptor: CourseQueryEncrypting? = nil,
+        networkStatusProvider: NetworkStatusProviding? = nil
     ) {
         // Cache 與 Parser 預設注入
         let cache = DefaultsCourseCache(
@@ -45,27 +44,15 @@ import SwiftUI
         self.repo = repository ?? DefaultCourseRepository(api: api, cache: cache, parser: parser)
         self.nextUp = nextUpService
 
-        if let enc = encryptor {
-            self.encryptor = enc
-        } else if let key = KeychainManager.shared.get(forKey: Constants.keychainAESKey),
-            let iv = KeychainManager.shared.get(forKey: Constants.keychainAESIV)
-        {
-            let helper = CustomAES256Helper(key: key, iv: iv)
-            self.encryptor = { helper.encrypt(data: $0) }
-            Self.logger.debug("Successfully initialized AES256 helper")
-        } else {
-            self.encryptor = { _ in nil }
-            self.errorMessage = "Failed to retrieve AES256 key or IV from Keychain."
-            Self.logger.error("Failed to retrieve AES256 key or IV from Keychain")
-        }
-
-        self.monitor = NWPathMonitor()
+        self.queryEncryptor = queryEncryptor ?? DefaultCourseQueryEncryptor()
+        self.networkStatusProvider = networkStatusProvider ?? DefaultNetworkStatusProvider()
+        self.isNetworkAvailable = self.networkStatusProvider.isNetworkAvailable
         startNetworkMonitor()
     }
 
     deinit {
         cacheMessageTask?.cancel()
-        monitor.cancel()
+        networkStatusProvider.stopMonitoring()
     }
 
     private func scheduleCacheMessageClear() {
@@ -78,10 +65,10 @@ import SwiftUI
     }
 
     private func startNetworkMonitor() {
-        monitor.pathUpdateHandler = { [weak self] path in
+        networkStatusProvider.startMonitoring { [weak self] isAvailable in
             Task { @MainActor [weak self] in
                 guard let self = self else { return }
-                self.isNetworkAvailable = (path.status == .satisfied)
+                self.isNetworkAvailable = isAvailable
                 if self.isNetworkAvailable {
                     Self.logger.debug("Network is available")
                     self.errorMessage = nil
@@ -91,7 +78,6 @@ import SwiftUI
                 }
             }
         }
-        monitor.start(queue: monitorQueue)
     }
 
     // 與舊版相同的快取 API（對外行為不變）
@@ -151,7 +137,7 @@ import SwiftUI
         self.cacheUpdateMessage = "Updating course data..."
 
         do {
-            guard let encryptedQuery = encryptor("20220901200540356," + stdNo) else {
+            guard let encryptedQuery = queryEncryptor.encryptedQuery(stdNo: stdNo) else {
                 throw URLError(.cannotParseResponse)
             }
             let courses = try await repo.fetchRemote(encryptedQuery: encryptedQuery)

--- a/app/dauphin/ViewModels/CourseViewModel.swift
+++ b/app/dauphin/ViewModels/CourseViewModel.swift
@@ -18,8 +18,8 @@ import SwiftUI
     // 內部依賴
     private let repo: CourseRepository
     private let nextUp: NextUpService
-    private let queryEncryptor: CourseQueryEncrypting
-    private let networkStatusProvider: NetworkStatusProviding
+    private let queryEncryptor: CourseQueryEncryptor
+    private let networkStatusProvider: NetworkStatusProvider
 
     // 網路狀態（維持原行為）
     private var isNetworkAvailable = true
@@ -30,8 +30,8 @@ import SwiftUI
     // 預設建構符合舊使用方式（不改外部）
     init(
         repository: CourseRepository? = nil, nextUpService: NextUpService = DefaultNextUpService(),
-        queryEncryptor: CourseQueryEncrypting? = nil,
-        networkStatusProvider: NetworkStatusProviding? = nil
+        queryEncryptor: CourseQueryEncryptor? = nil,
+        networkStatusProvider: NetworkStatusProvider? = nil
     ) {
         // Cache 與 Parser 預設注入
         let cache = DefaultsCourseCache(


### PR DESCRIPTION
## Summary
- extract course query encryption from `CourseViewModel` into an injectable `CourseQueryEncrypting` service
- extract network monitoring from `CourseViewModel` into an injectable `NetworkStatusProviding` service
- keep `CourseViewModel` focused on state/orchestration and extend tests for offline and encryption-failure flows

Fixes #36

## Testing
- swift-format lint --configuration app/.swift-format --recursive .
- xcodebuild -project app/dauphin.xcodeproj -scheme dauphin -testPlan Models -destination 'id=EA0D1D18-8BA5-4248-AC5B-57799C06AB86' test