### PR TITLE
chore(ci): add Localizable.xcstrings validation guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,23 +62,11 @@ jobs:
   localization_check:
     name: localization-check
     runs-on: ubuntu-latest
-    needs: swift_format
     steps:
       - uses: actions/checkout@v4
 
-      - name: Detect localization catalog changes
-        id: changed-files
-        uses: tj-actions/changed-files@v46
-        with:
-          files: app/dauphin/Localizable.xcstrings
-
       - name: Check localizations
-        if: steps.changed-files.outputs.any_changed == 'true'
         run: python3 scripts/check_localizations.py
-
-      - name: Skip unchanged catalog
-        if: steps.changed-files.outputs.any_changed != 'true'
-        run: echo "Localizable.xcstrings unchanged, skipping localization check."
 
   test:
     name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,14 @@ on:
   pull_request:
     paths:
       - "app/**"
+      - "scripts/**"
       - ".github/workflows/ci.yml"
   push:
     branches:
       - dev
     paths:
       - "app/**"
+      - "scripts/**"
       - ".github/workflows/ci.yml"
   workflow_dispatch:
 
@@ -34,7 +36,7 @@ jobs:
   build:
     name: build
     runs-on: macos-latest
-    needs: swift_format
+    needs: [swift_format, localization_check]
     steps:
       - uses: actions/checkout@v4
           
@@ -56,6 +58,27 @@ jobs:
             -destination 'generic/platform=iOS Simulator' \
             -sdk iphonesimulator \
             clean build
+
+  localization_check:
+    name: localization-check
+    runs-on: ubuntu-latest
+    needs: swift_format
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect localization catalog changes
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: app/dauphin/Localizable.xcstrings
+
+      - name: Check localizations
+        if: steps.changed-files.outputs.any_changed == 'true'
+        run: python3 scripts/check_localizations.py
+
+      - name: Skip unchanged catalog
+        if: steps.changed-files.outputs.any_changed != 'true'
+        run: echo "Localizable.xcstrings unchanged, skipping localization check."
 
   test:
     name: test

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ CLAUDE_*.md
 
 # XcodeBuildMCP
 .xcodebuildmcp/
+
+# Python
+__pycache__/
+*.pyc

--- a/app/dauphin/Localizable.xcstrings
+++ b/app/dauphin/Localizable.xcstrings
@@ -101,6 +101,12 @@
     },
     "⚠️This app isn’t developed by Tamkang University Office of Information Services. Use at your own risk." : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "⚠️This app isn’t developed by Tamkang University Office of Information Services. Use at your own risk."
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -127,6 +133,12 @@
     },
     "Account" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Account"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -136,7 +148,20 @@
       }
     },
     "Add to Calendar" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Add to Calendar"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "加入行事曆"
+          }
+        }
+      }
     },
     "App Information" : {
       "localizations" : {
@@ -172,7 +197,20 @@
       }
     },
     "Cache cleared successfully" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cache cleared successfully"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "快取已成功清除"
+          }
+        }
+      }
     },
     "calendar" : {
       "extractionState" : "manual",
@@ -193,6 +231,12 @@
     },
     "Calendar" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Calendar"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -203,6 +247,12 @@
     },
     "Campus Map" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Campus Map"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -212,16 +262,68 @@
       }
     },
     "Cancel" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancel"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "取消"
+          }
+        }
+      }
     },
     "Clear" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除"
+          }
+        }
+      }
     },
     "Clear Cache" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear Cache"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除快取"
+          }
+        }
+      }
     },
     "Clear cached course data to free up storage" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear cached course data to free up storage"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除已快取的課程資料以釋放儲存空間"
+          }
+        }
+      }
     },
     "Coming Soon" : {
       "localizations" : {
@@ -271,8 +373,181 @@
         }
       }
     },
+    "course.detail.instructor" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Instructor"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "授課教師"
+          }
+        }
+      }
+    },
+    "course.detail.location" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Location"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地點"
+          }
+        }
+      }
+    },
+    "course.detail.note" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "備註"
+          }
+        }
+      }
+    },
+    "course.detail.seatNumber" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seat Number"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "座號"
+          }
+        }
+      }
+    },
+    "course.detail.time" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Time"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "時間"
+          }
+        }
+      }
+    },
+    "course.detail.day" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Day"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "星期"
+          }
+        }
+      }
+    },
+    "course.detail.section.details" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Details"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "課程資訊"
+          }
+        }
+      }
+    },
+    "course.detail.section.map" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Map"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地圖"
+          }
+        }
+      }
+    },
+    "course.detail.section.note" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Note"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "備註"
+          }
+        }
+      }
+    },
+    "course.detail.section.schedule" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Schedule"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "課程時間"
+          }
+        }
+      }
+    },
     "Data Management" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Data Management"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "資料管理"
+          }
+        }
+      }
     },
     "Data Sources and Resources" : {
       "localizations" : {
@@ -291,11 +566,30 @@
       }
     },
     "Enjoy your free day!" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enjoy your free day!"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "好好享受你的空堂日！"
+          }
+        }
+      }
     },
     "First" : {
       "extractionState" : "stale",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "First"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -305,7 +599,20 @@
       }
     },
     "Hey, %@" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hey, %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "嗨，%@"
+          }
+        }
+      }
     },
     "Hey, %@." : {
       "extractionState" : "stale",
@@ -326,6 +633,12 @@
     },
     "iOS Feature Support" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "iOS Feature Support"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -336,6 +649,12 @@
     },
     "Library" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Library"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -380,6 +699,12 @@
     },
     "Local First" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Local First"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -389,11 +714,30 @@
       }
     },
     "Locations" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Locations"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "地點"
+          }
+        }
+      }
     },
     "Log out" : {
       "extractionState" : "stale",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Log out"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -403,7 +747,20 @@
       }
     },
     "Logout" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Logout"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "登出"
+          }
+        }
+      }
     },
     "No courses for %@." : {
       "extractionState" : "stale",
@@ -423,19 +780,77 @@
       }
     },
     "No courses for Today" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No courses for Today"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "今天沒有課程"
+          }
+        }
+      }
     },
     "Open in Apple Maps" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open in Apple Maps"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Apple 地圖中開啟"
+          }
+        }
+      }
     },
     "Open in Google Maps" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open in Google Maps"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在 Google 地圖中開啟"
+          }
+        }
+      }
     },
     "Open in Maps" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open in Maps"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "在地圖中開啟"
+          }
+        }
+      }
     },
     "Open Source" : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Open Source"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -463,6 +878,12 @@
     "Second" : {
       "extractionState" : "stale",
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Second"
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -472,10 +893,36 @@
       }
     },
     "Select a setting" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select a setting"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇一項設定"
+          }
+        }
+      }
     },
     "Select an option" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Select an option"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "選擇一個選項"
+          }
+        }
+      }
     },
     "Setting" : {
       "localizations" : {
@@ -494,7 +941,20 @@
       }
     },
     "Settings" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Settings"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "設定"
+          }
+        }
+      }
     },
     "stdID:%@" : {
       "extractionState" : "manual",
@@ -514,7 +974,20 @@
       }
     },
     "Student ID: %@" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Student ID: %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "學號：%@"
+          }
+        }
+      }
     },
     "Third-Party Packages" : {
       "localizations" : {
@@ -533,7 +1006,20 @@
       }
     },
     "This will remove all cached course data. You'll need to refresh to reload your courses." : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This will remove all cached course data. You'll need to refresh to reload your courses."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "這會移除所有已快取的課程資料。你需要重新整理以重新載入課程。"
+          }
+        }
+      }
     },
     "Version" : {
       "localizations" : {
@@ -553,6 +1039,12 @@
     },
     "We securely cache some redundant data locally, so you can still access your schedule without connecting to the school's server." : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We securely cache some redundant data locally, so you can still access your schedule without connecting to the school's server."
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -563,6 +1055,12 @@
     },
     "We support many iOS features like Widgets, and we'll update further as inspiration strikes." : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We support many iOS features like Widgets, and we'll update further as inspiration strikes."
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -573,6 +1071,12 @@
     },
     "We're open-sourcing our code. If you're not satisfied with the current version, feel free to fork it on GitHub." : {
       "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "We're open-sourcing our code. If you're not satisfied with the current version, feel free to fork it on GitHub."
+          }
+        },
         "zh-Hant" : {
           "stringUnit" : {
             "state" : "translated",
@@ -598,10 +1102,36 @@
       }
     },
     "Your student ID is %@" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Your student ID is %@"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "你的學號是 %@"
+          }
+        }
+      }
     },
     "校務行事曆" : {
-
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Academic Calendar"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "校務行事曆"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/app/dauphin/Localizable.xcstrings
+++ b/app/dauphin/Localizable.xcstrings
@@ -1,23 +1,6 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
-    ": %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ": %@"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : ": %@"
-          }
-        }
-      }
-    },
     "%@" : {
       "localizations" : {
         "en" : {
@@ -46,23 +29,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ - %2$@ "
-          }
-        }
-      }
-    },
-    "%@ ~ %@" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ ~ %2$@"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ ~ %2$@"
           }
         }
       }
@@ -175,23 +141,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "程式資訊"
-          }
-        }
-      }
-    },
-    "Browse" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Browse"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "瀏覽"
           }
         }
       }
@@ -581,23 +530,6 @@
         }
       }
     },
-    "First" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "First"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "上"
-          }
-        }
-      }
-    },
     "Hey, %@" : {
       "localizations" : {
         "en" : {
@@ -610,23 +542,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "嗨，%@"
-          }
-        }
-      }
-    },
-    "Hey, %@." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hey, %@."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "嗨, %@"
           }
         }
       }
@@ -659,23 +574,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "圖書館"
-          }
-        }
-      }
-    },
-    "Loading courses..." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Loading courses..."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "載入課程"
           }
         }
       }
@@ -729,23 +627,6 @@
         }
       }
     },
-    "Log out" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Log out"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "登出"
-          }
-        }
-      }
-    },
     "Logout" : {
       "localizations" : {
         "en" : {
@@ -758,23 +639,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "登出"
-          }
-        }
-      }
-    },
-    "No courses for %@." : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No courses for %@."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@沒有課程"
           }
         }
       }
@@ -871,23 +735,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "其他"
-          }
-        }
-      }
-    },
-    "Second" : {
-      "extractionState" : "stale",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Second"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "下"
           }
         }
       }

--- a/app/dauphin/Localizable.xcstrings
+++ b/app/dauphin/Localizable.xcstrings
@@ -262,6 +262,12 @@
             "state" : "translated",
             "value" : "Course"
           }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "課程"
+          }
         }
       }
     },

--- a/app/dauphin/Localizable.xcstrings
+++ b/app/dauphin/Localizable.xcstrings
@@ -262,12 +262,6 @@
             "state" : "translated",
             "value" : "Course"
           }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "課程"
-          }
         }
       }
     },

--- a/app/dauphin/View/CourseSchedule/Shared/CourseDetailView.swift
+++ b/app/dauphin/View/CourseSchedule/Shared/CourseDetailView.swift
@@ -5,31 +5,100 @@
 //  Created on 2025-09-19.
 //
 
+import Foundation
 import SwiftUI
 
 struct CourseDetailView: View {
     let course: Course
-    @Environment(\.dismiss) var dismiss
-
-    // Cache expensive computations
-    private let dayOfWeek: String
-    private let timeRange: String
-    private let hasNote: Bool
+    @Environment(\.dismiss) private var dismiss
+    private let viewData: CourseDetailViewData
 
     init(course: Course) {
         self.course = course
+        viewData = CourseDetailViewData(course: course)
+    }
 
-        let days = [
-            "", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
-        ]
-        dayOfWeek = days[min(max(course.weekday, 0), days.count - 1)]
+    var body: some View {
+        NavigationStack {
+            List {
+                scheduleSection
+                detailsSection
+                if viewData.hasNote { noteSection }
+                mapSection
+            }.listStyle(.insetGrouped).navigationTitle(course.name).navigationBarTitleDisplayMode(
+                .inline
+            ).toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: dismiss.callAsFunction) {
+                        Image(systemName: "xmark").frame(width: 44, height: 44)
+                    }
+                }
+            }
+        }
+    }
 
-        let formatter = CourseDetailView.timeFormatter
+    // MARK: - Sections
+
+    private var scheduleSection: some View {
+        Section {
+            LabeledContent(LocalizedStringKey("course.detail.time"), value: viewData.timeRangeText)
+            LabeledContent(LocalizedStringKey("course.detail.day"), value: viewData.dayText)
+        } header: {
+            Text(LocalizedStringKey("course.detail.section.schedule"))
+        }
+    }
+
+    private var detailsSection: some View {
+        Section {
+            LabeledContent(LocalizedStringKey("course.detail.location"), value: course.room)
+            LabeledContent(LocalizedStringKey("course.detail.seatNumber"), value: course.stdNo)
+            LabeledContent(LocalizedStringKey("course.detail.instructor"), value: course.teacher)
+        } header: {
+            Text(LocalizedStringKey("course.detail.section.details"))
+        }
+    }
+
+    private var noteSection: some View {
+        Section {
+            Text(course.note).font(.body).lineSpacing(3).fixedSize(
+                horizontal: false, vertical: true)
+        } header: {
+            Text(LocalizedStringKey("course.detail.section.note"))
+        }
+    }
+
+    private var mapSection: some View {
+        Section {
+            LandmarkView(coordinate: letterToCoordinate(for: viewData.roomCode)).padding(
+                .horizontal, 6
+            ).padding(.vertical, 4).listRowInsets(
+                EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+            ).listRowBackground(Color.clear)
+        } header: {
+            Text(LocalizedStringKey("course.detail.section.map"))
+        }
+    }
+}
+
+// MARK: - View Data
+
+private struct CourseDetailViewData {
+    let timeRangeText: String
+    let dayText: String
+    let hasNote: Bool
+    let roomCode: String
+
+    init(course: Course) {
+        let formatter = Self.timeFormatter
         let start = formatter.string(from: course.startTime)
         let end = formatter.string(from: course.endTime)
-        timeRange = "\(start) - \(end)"
-
-        hasNote = !course.note.isEmpty
+        timeRangeText = "\(start) - \(end)"
+        dayText = Self.localizedWeekdayText(for: course.weekday)
+        hasNote = !course.note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        roomCode =
+            course.room.range(of: #"^[A-Za-z]+"#, options: .regularExpression).map {
+                String(course.room[$0]).uppercased()
+            } ?? "X"
     }
 
     private static let timeFormatter: DateFormatter = {
@@ -38,59 +107,14 @@ struct CourseDetailView: View {
         return formatter
     }()
 
-    var body: some View {
-        NavigationView {
-            ScrollView {
-                VStack(alignment: .leading, spacing: 10) {
-                    detailRow(title: "Time", content: timeRange, subcontent: dayOfWeek)
-                    Divider()
-                    detailRow(title: "Location", content: course.room)
-                    Divider()
-                    detailRow(title: "Seat Number", content: course.stdNo)
-                    Divider()
-                    detailRow(title: "Instructor", content: course.teacher)
-
-                    if hasNote {
-                        Divider()
-                        detailRow(title: "Note", content: course.note, isNote: true)
-                    }
-                    let code =
-                        course.room.range(of: #"^[A-Za-z]+"#, options: .regularExpression).map {
-                            String(course.room[$0]).uppercased()
-                        } ?? "X"
-
-                    LandmarkView(coordinate: letterToCoordinate(for: code))
-
-                }.padding(24)
-
-            }.navigationTitle(course.name).navigationBarTitleDisplayMode(.large).toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    Button {
-                        dismiss()
-                    } label: {
-                        Image(systemName: "xmark")
-                    }
-                }
-            }
-        }
-    }
-
-    @ViewBuilder private func detailRow(
-        title: String, content: String, subcontent: String? = nil, isNote: Bool = false
-    ) -> some View {
-        HStack(spacing: 4) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text(title).font(.caption).foregroundColor(Color(UIColor.secondaryLabel))
-                if let subcontent = subcontent {
-                    Text(subcontent).font(.system(size: 14)).foregroundColor(
-                        Color(UIColor.secondaryLabel))
-                }
-                Text(content).font(
-                    .system(size: isNote ? 14 : 16, weight: isNote ? .regular : .medium)
-                ).foregroundColor(Color(UIColor.label)).fixedSize(
-                    horizontal: false, vertical: isNote)
-            }
-        }
+    private static func localizedWeekdayText(for weekday: Int) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = .autoupdatingCurrent
+        let symbols = formatter.weekdaySymbols ?? []
+        guard !symbols.isEmpty else { return "" }
+        let normalizedWeekday = min(max(weekday, 1), 7)
+        let symbolIndex = normalizedWeekday % 7
+        return symbols[symbolIndex]
     }
 }
 

--- a/scripts/check_localizations.py
+++ b/scripts/check_localizations.py
@@ -9,7 +9,7 @@ LOCALIZATIONS = ("en", "zh-Hant")
 XCSTRINGS_PATH = Path("app/dauphin/Localizable.xcstrings")
 
 
-def read_catalog(path: Path) -> dict:
+def read_catalog(path: Path):
     try:
         return json.loads(path.read_text(encoding="utf-8"))
     except FileNotFoundError:
@@ -21,22 +21,34 @@ def read_catalog(path: Path) -> dict:
 
 
 def missing_value(entry: dict, locale: str) -> bool:
-    localizations = entry.get("localizations", {})
-    locale_entry = localizations.get(locale, {})
-    string_unit = locale_entry.get("stringUnit", {})
+    localizations = entry.get("localizations")
+    if not isinstance(localizations, dict):
+        return True
+
+    locale_entry = localizations.get(locale)
+    if not isinstance(locale_entry, dict):
+        return True
+
+    string_unit = locale_entry.get("stringUnit")
+    if not isinstance(string_unit, dict):
+        return True
+
     value = string_unit.get("value")
     return not isinstance(value, str) or not value.strip()
 
 
 def main() -> int:
     catalog = read_catalog(XCSTRINGS_PATH)
+    if not isinstance(catalog, dict):
+        print("ERROR: localization catalog root must be a JSON object")
+        return 1
+
     strings = catalog.get("strings")
     if not isinstance(strings, dict):
         print("ERROR: missing or invalid `strings` object in Localizable.xcstrings")
         return 1
 
-    missing_en = []
-    missing_zh_hant = []
+    missing_by_locale = {locale: [] for locale in LOCALIZATIONS}
     stale_keys = []
 
     for key, entry in strings.items():
@@ -46,29 +58,24 @@ def main() -> int:
         if entry.get("extractionState") == "stale":
             stale_keys.append(key)
 
-        if missing_value(entry, "en"):
-            missing_en.append(key)
-        if missing_value(entry, "zh-Hant"):
-            missing_zh_hant.append(key)
+        for locale in LOCALIZATIONS:
+            if missing_value(entry, locale):
+                missing_by_locale[locale].append(key)
 
     has_error = False
 
-    if missing_en:
-        has_error = True
-        print("ERROR: missing `en` localization values:")
-        for key in missing_en:
-            print(f"  - {key}")
-
-    if missing_zh_hant:
-        has_error = True
-        print("ERROR: missing `zh-Hant` localization values:")
-        for key in missing_zh_hant:
-            print(f"  - {key}")
+    for locale in LOCALIZATIONS:
+        missing_keys = sorted(missing_by_locale[locale])
+        if missing_keys:
+            has_error = True
+            print(f"ERROR: missing `{locale}` localization values:")
+            for key in missing_keys:
+                print(f"  - {key}")
 
     if stale_keys:
         has_error = True
         print("ERROR: stale localization keys present:")
-        for key in stale_keys:
+        for key in sorted(stale_keys):
             print(f"  - {key}")
 
     if has_error:

--- a/scripts/check_localizations.py
+++ b/scripts/check_localizations.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+import json
+import sys
+from pathlib import Path
+
+
+LOCALIZATIONS = ("en", "zh-Hant")
+XCSTRINGS_PATH = Path("app/dauphin/Localizable.xcstrings")
+
+
+def read_catalog(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        print(f"ERROR: localization catalog not found: {path}")
+        sys.exit(1)
+    except json.JSONDecodeError as error:
+        print(f"ERROR: invalid JSON in {path}: {error}")
+        sys.exit(1)
+
+
+def missing_value(entry: dict, locale: str) -> bool:
+    localizations = entry.get("localizations", {})
+    locale_entry = localizations.get(locale, {})
+    string_unit = locale_entry.get("stringUnit", {})
+    value = string_unit.get("value")
+    return not isinstance(value, str) or not value.strip()
+
+
+def main() -> int:
+    catalog = read_catalog(XCSTRINGS_PATH)
+    strings = catalog.get("strings")
+    if not isinstance(strings, dict):
+        print("ERROR: missing or invalid `strings` object in Localizable.xcstrings")
+        return 1
+
+    missing_en = []
+    missing_zh_hant = []
+    stale_keys = []
+
+    for key, entry in strings.items():
+        if not isinstance(entry, dict):
+            continue
+
+        if entry.get("extractionState") == "stale":
+            stale_keys.append(key)
+
+        if missing_value(entry, "en"):
+            missing_en.append(key)
+        if missing_value(entry, "zh-Hant"):
+            missing_zh_hant.append(key)
+
+    has_error = False
+
+    if missing_en:
+        has_error = True
+        print("ERROR: missing `en` localization values:")
+        for key in missing_en:
+            print(f"  - {key}")
+
+    if missing_zh_hant:
+        has_error = True
+        print("ERROR: missing `zh-Hant` localization values:")
+        for key in missing_zh_hant:
+            print(f"  - {key}")
+
+    if stale_keys:
+        has_error = True
+        print("ERROR: stale localization keys present:")
+        for key in stale_keys:
+            print(f"  - {key}")
+
+    if has_error:
+        print(
+            "\nLocalization check failed. Fill both locales and remove stale keys in "
+            "app/dauphin/Localizable.xcstrings."
+        )
+        return 1
+
+    print("Localization check passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add `scripts/check_localizations.py` to validate `app/dauphin/Localizable.xcstrings` JSON, required locale values (`en`, `zh-Hant`), and stale extraction keys
- add a `localization-check` CI job in `.github/workflows/ci.yml`
- run the localization check only when `Localizable.xcstrings` changes, so we can merge the guardrail before #51 cleanup lands

## Notes
- when `Localizable.xcstrings` is changed, this job fails on missing locale values or stale keys