### PR TITLE
perf(ci): skip heavy Xcode jobs on non-app changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,20 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: detect-changes
+    runs-on: ubuntu-latest
+    outputs:
+      app_changed: ${{ steps.changed-files.outputs.any_changed }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Detect app changes
+        id: changed-files
+        uses: tj-actions/changed-files@v46
+        with:
+          files: app/**
+
   swift_format:
     name: swift-format
     runs-on: macos-latest
@@ -34,7 +48,8 @@ jobs:
   build:
     name: build
     runs-on: macos-latest
-    needs: swift_format
+    needs: [changes, swift_format]
+    if: needs.changes.outputs.app_changed == 'true'
     steps:
       - uses: actions/checkout@v4
           
@@ -55,12 +70,13 @@ jobs:
             -configuration Debug \
             -destination 'generic/platform=iOS Simulator' \
             -sdk iphonesimulator \
-            clean build
+            build
 
   test:
     name: test
     runs-on: macos-latest
-    needs: build
+    needs: [changes, build]
+    if: needs.changes.outputs.app_changed == 'true'
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- add a `detect-changes` job to detect whether files under `app/**` changed
- run `build` and `test` jobs only when app files changed
- remove `clean` from the build command to reduce redundant compile time in CI

## Why
Most CI time is spent in Xcode build/test. For PRs that only touch workflow/docs/scripts, we can safely skip heavy iOS jobs while still running formatting checks.

## Impact
- faster PR turnaround for non-app changes
- no change to build/test coverage when app code actually changes