### PR TITLE
refactor(i18n): localize key UI strings and add uv catalog check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,8 +65,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: astral-sh/setup-uv@v6
+
       - name: Check localizations
-        run: python3 scripts/check_localizations.py
+        run: uv run scripts/check_localizations.py
 
   test:
     name: test

--- a/app/CoursesWidget/Views/NextUpLockScreenView.swift
+++ b/app/CoursesWidget/Views/NextUpLockScreenView.swift
@@ -11,7 +11,7 @@ struct CoursesNextUpViewLockScreenView: View {
                 Image(systemName: "person.text.rectangle.trianglebadge.exclamationmark.fill").font(
                     .system(size: 40, weight: .semibold))
 
-                Text("尚未登入").font(.caption).fontWeight(.medium)
+                Text(LocalizedStringKey("widget.notLoggedIn")).font(.caption).fontWeight(.medium)
             }.frame(maxWidth: .infinity, maxHeight: .infinity).containerBackground(for: .widget) {
                 Color(UIColor.systemBackground)
             }
@@ -20,7 +20,8 @@ struct CoursesNextUpViewLockScreenView: View {
                 HStack(spacing: 10) {
                     Image(systemName: "figure.wave").font(.system(size: 40, weight: .semibold))
 
-                    Text("下週見").font(.caption).fontWeight(.medium)
+                    Text(LocalizedStringKey("widget.seeYouNextWeek")).font(.caption).fontWeight(
+                        .medium)
                 }.frame(maxWidth: .infinity, maxHeight: .infinity).containerBackground(for: .widget)
                 { Color(UIColor.systemBackground) }
             } else {
@@ -41,7 +42,7 @@ struct CoursesNextUpViewLockScreenView: View {
                             HStack(spacing: 0) {
                                 Image(systemName: "location.circle").resizable().frame(
                                     width: 15, height: 15)
-                                Text(" : \(entry.courses[0].room)").font(.system(size: 12))
+                                Text(entry.courses[0].room).font(.system(size: 12))
                             }
 
                             Spacer(minLength: 20)
@@ -49,7 +50,7 @@ struct CoursesNextUpViewLockScreenView: View {
                             HStack(spacing: 0) {
                                 Image(systemName: "graduationcap").resizable().frame(
                                     width: 15, height: 15)
-                                Text(" : \(entry.courses[0].stdNo)").font(.system(size: 12))
+                                Text(entry.courses[0].stdNo).font(.system(size: 12))
                             }
                         }
                     }

--- a/app/CoursesWidget/Views/NextUpSmallView.swift
+++ b/app/CoursesWidget/Views/NextUpSmallView.swift
@@ -28,9 +28,11 @@ struct CoursesNextUpSmallView: View {
         return names[index]
     }
 
-    private static let weekdaySymbols: [String] = [
-        "Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday",
-    ]
+    private static let weekdaySymbols: [String] = {
+        let formatter = DateFormatter()
+        formatter.locale = .autoupdatingCurrent
+        return formatter.weekdaySymbols
+    }()
 
     var body: some View {
         if entry.ssoStuNo.isEmpty {
@@ -38,7 +40,7 @@ struct CoursesNextUpSmallView: View {
                 Image(systemName: "person.text.rectangle.trianglebadge.exclamationmark.fill").font(
                     .system(size: 60, weight: .semibold))
 
-                Text("尚未登入").font(.caption).fontWeight(.medium)
+                Text(LocalizedStringKey("widget.notLoggedIn")).font(.caption).fontWeight(.medium)
             }.frame(maxWidth: .infinity, maxHeight: .infinity).containerBackground(for: .widget) {
                 Color(UIColor.systemBackground)
             }
@@ -47,7 +49,8 @@ struct CoursesNextUpSmallView: View {
                 VStack(spacing: 8) {
                     Image(systemName: "figure.wave").font(.system(size: 60, weight: .semibold))
 
-                    Text("下週見").font(.caption).fontWeight(.medium)
+                    Text(LocalizedStringKey("widget.seeYouNextWeek")).font(.caption).fontWeight(
+                        .medium)
                 }.frame(maxWidth: .infinity, maxHeight: .infinity).containerBackground(for: .widget)
                 { Color(UIColor.systemBackground) }
             } else {

--- a/app/StdID/StdID.swift
+++ b/app/StdID/StdID.swift
@@ -53,7 +53,8 @@ struct StdIDEntryView: View {
                 VStack(spacing: 8) {
                     Image(systemName: "person.text.rectangle.trianglebadge.exclamationmark.fill")
                         .font(.system(size: 60, weight: .semibold))
-                    Text("尚未登入").font(.caption).fontWeight(.medium)
+                    Text(LocalizedStringKey("widget.notLoggedIn")).font(.caption).fontWeight(
+                        .medium)
                 }.frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }.padding(12).foregroundStyle(.black).background(Color.white)
@@ -71,8 +72,8 @@ struct StdID: Widget {
             } else {
                 StdIDEntryView(entry: entry).environment(\.colorScheme, .light)
             }
-        }.configurationDisplayName("Student Barcode").description(
-            "Showing your StudentID use barcode."
+        }.configurationDisplayName(LocalizedStringResource("widget.stdid.displayName")).description(
+            LocalizedStringResource("widget.stdid.description")
         ).supportedFamilies([.systemMedium])
     }
 }

--- a/app/StdID/StdID.swift
+++ b/app/StdID/StdID.swift
@@ -72,8 +72,8 @@ struct StdID: Widget {
             } else {
                 StdIDEntryView(entry: entry).environment(\.colorScheme, .light)
             }
-        }.configurationDisplayName(LocalizedStringResource("widget.stdid.displayName")).description(
-            LocalizedStringResource("widget.stdid.description")
+        }.configurationDisplayName(String(localized: "widget.stdid.displayName")).description(
+            String(localized: "widget.stdid.description")
         ).supportedFamilies([.systemMedium])
     }
 }

--- a/app/Tests/ModelsTests/CourseViewModelTests.swift
+++ b/app/Tests/ModelsTests/CourseViewModelTests.swift
@@ -78,7 +78,7 @@ private final class MockNetworkStatusProvider: NetworkStatusProvider, @unchecked
         #expect(repo.didClear)
         #expect(vm.weekCourses.isEmpty)
         #expect(vm.isCacheEmpty)
-        #expect(vm.errorMessage == "Cache cleared. Please refresh to load courses.")
+        #expect(vm.errorMessage == String(localized: "course.cache.cleared"))
     }
 
     @Test("first login fetch loads remote and saves cache")
@@ -125,7 +125,7 @@ private final class MockNetworkStatusProvider: NetworkStatusProvider, @unchecked
         await vm.fetchCourses(with: "410000000", isFirstLogin: true)
 
         #expect(repo.fetchCount == 0)
-        #expect(vm.errorMessage == "No internet connection and no cached data available.")
+        #expect(vm.errorMessage == String(localized: "course.error.noInternetNoCache"))
     }
 
     @Test("encryption failure skips remote fetch and reports error")
@@ -136,6 +136,6 @@ private final class MockNetworkStatusProvider: NetworkStatusProvider, @unchecked
         await vm.fetchCourses(with: "410000000", isFirstLogin: true)
 
         #expect(repo.fetchCount == 0)
-        #expect(vm.errorMessage == "Failed to fetch courses.")
+        #expect(vm.errorMessage == String(localized: "course.error.fetchFailed"))
     }
 }

--- a/app/dauphin/Localizable.xcstrings
+++ b/app/dauphin/Localizable.xcstrings
@@ -964,6 +964,70 @@
         }
       }
     },
+    "widget.notLoggedIn" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Not logged in"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "尚未登入"
+          }
+        }
+      }
+    },
+    "widget.seeYouNextWeek" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "See you next week"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下週見"
+          }
+        }
+      }
+    },
+    "widget.stdid.description" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show your student ID barcode."
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示你的學號條碼。"
+          }
+        }
+      }
+    },
+    "widget.stdid.displayName" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Student Barcode"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "學生條碼"
+          }
+        }
+      }
+    },
     "校務行事曆" : {
       "localizations" : {
         "en" : {

--- a/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
+++ b/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
@@ -12,12 +12,17 @@ struct DayScheduleView: View {
     private static let monthYearStyle = Date.FormatStyle.dateTime.month(.wide).year(.defaultDigits)
         .locale(.autoupdatingCurrent)
 
+    private var greetingText: String {
+        String.localizedStringWithFormat(
+            NSLocalizedString("Hey, %@", comment: ""), authViewModel.ssoStuNo)
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             // Header Section
             VStack(alignment: .leading, spacing: 8) {
                 HStack(spacing: 0) {
-                    Text("Hey, \(authViewModel.ssoStuNo)").font(.title).fontWeight(.bold)
+                    Text(greetingText).font(.title).fontWeight(.bold)
 
                     Spacer()
 

--- a/app/dauphin/View/CourseSchedule/Shared/CourseDetailView.swift
+++ b/app/dauphin/View/CourseSchedule/Shared/CourseDetailView.swift
@@ -5,100 +5,31 @@
 //  Created on 2025-09-19.
 //
 
-import Foundation
 import SwiftUI
 
 struct CourseDetailView: View {
     let course: Course
-    @Environment(\.dismiss) private var dismiss
-    private let viewData: CourseDetailViewData
+    @Environment(\.dismiss) var dismiss
+
+    // Cache expensive computations
+    private let dayOfWeek: String
+    private let timeRange: String
+    private let hasNote: Bool
 
     init(course: Course) {
         self.course = course
-        viewData = CourseDetailViewData(course: course)
-    }
 
-    var body: some View {
-        NavigationStack {
-            List {
-                scheduleSection
-                detailsSection
-                if viewData.hasNote { noteSection }
-                mapSection
-            }.listStyle(.insetGrouped).navigationTitle(course.name).navigationBarTitleDisplayMode(
-                .inline
-            ).toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
-                    Button(action: dismiss.callAsFunction) {
-                        Image(systemName: "xmark").frame(width: 44, height: 44)
-                    }
-                }
-            }
-        }
-    }
+        let days = [
+            "", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday",
+        ]
+        dayOfWeek = days[min(max(course.weekday, 0), days.count - 1)]
 
-    // MARK: - Sections
-
-    private var scheduleSection: some View {
-        Section {
-            LabeledContent(LocalizedStringKey("course.detail.time"), value: viewData.timeRangeText)
-            LabeledContent(LocalizedStringKey("course.detail.day"), value: viewData.dayText)
-        } header: {
-            Text(LocalizedStringKey("course.detail.section.schedule"))
-        }
-    }
-
-    private var detailsSection: some View {
-        Section {
-            LabeledContent(LocalizedStringKey("course.detail.location"), value: course.room)
-            LabeledContent(LocalizedStringKey("course.detail.seatNumber"), value: course.stdNo)
-            LabeledContent(LocalizedStringKey("course.detail.instructor"), value: course.teacher)
-        } header: {
-            Text(LocalizedStringKey("course.detail.section.details"))
-        }
-    }
-
-    private var noteSection: some View {
-        Section {
-            Text(course.note).font(.body).lineSpacing(3).fixedSize(
-                horizontal: false, vertical: true)
-        } header: {
-            Text(LocalizedStringKey("course.detail.section.note"))
-        }
-    }
-
-    private var mapSection: some View {
-        Section {
-            LandmarkView(coordinate: letterToCoordinate(for: viewData.roomCode)).padding(
-                .horizontal, 6
-            ).padding(.vertical, 4).listRowInsets(
-                EdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-            ).listRowBackground(Color.clear)
-        } header: {
-            Text(LocalizedStringKey("course.detail.section.map"))
-        }
-    }
-}
-
-// MARK: - View Data
-
-private struct CourseDetailViewData {
-    let timeRangeText: String
-    let dayText: String
-    let hasNote: Bool
-    let roomCode: String
-
-    init(course: Course) {
-        let formatter = Self.timeFormatter
+        let formatter = CourseDetailView.timeFormatter
         let start = formatter.string(from: course.startTime)
         let end = formatter.string(from: course.endTime)
-        timeRangeText = "\(start) - \(end)"
-        dayText = Self.localizedWeekdayText(for: course.weekday)
-        hasNote = !course.note.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        roomCode =
-            course.room.range(of: #"^[A-Za-z]+"#, options: .regularExpression).map {
-                String(course.room[$0]).uppercased()
-            } ?? "X"
+        timeRange = "\(start) - \(end)"
+
+        hasNote = !course.note.isEmpty
     }
 
     private static let timeFormatter: DateFormatter = {
@@ -107,14 +38,59 @@ private struct CourseDetailViewData {
         return formatter
     }()
 
-    private static func localizedWeekdayText(for weekday: Int) -> String {
-        let formatter = DateFormatter()
-        formatter.locale = .autoupdatingCurrent
-        let symbols = formatter.weekdaySymbols ?? []
-        guard !symbols.isEmpty else { return "" }
-        let normalizedWeekday = min(max(weekday, 1), 7)
-        let symbolIndex = normalizedWeekday % 7
-        return symbols[symbolIndex]
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 10) {
+                    detailRow(title: "Time", content: timeRange, subcontent: dayOfWeek)
+                    Divider()
+                    detailRow(title: "Location", content: course.room)
+                    Divider()
+                    detailRow(title: "Seat Number", content: course.stdNo)
+                    Divider()
+                    detailRow(title: "Instructor", content: course.teacher)
+
+                    if hasNote {
+                        Divider()
+                        detailRow(title: "Note", content: course.note, isNote: true)
+                    }
+                    let code =
+                        course.room.range(of: #"^[A-Za-z]+"#, options: .regularExpression).map {
+                            String(course.room[$0]).uppercased()
+                        } ?? "X"
+
+                    LandmarkView(coordinate: letterToCoordinate(for: code))
+
+                }.padding(24)
+
+            }.navigationTitle(course.name).navigationBarTitleDisplayMode(.large).toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        dismiss()
+                    } label: {
+                        Image(systemName: "xmark")
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder private func detailRow(
+        title: String, content: String, subcontent: String? = nil, isNote: Bool = false
+    ) -> some View {
+        HStack(spacing: 4) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title).font(.caption).foregroundColor(Color(UIColor.secondaryLabel))
+                if let subcontent = subcontent {
+                    Text(subcontent).font(.system(size: 14)).foregroundColor(
+                        Color(UIColor.secondaryLabel))
+                }
+                Text(content).font(
+                    .system(size: isNote ? 14 : 16, weight: isNote ? .regular : .medium)
+                ).foregroundColor(Color(UIColor.label)).fixedSize(
+                    horizontal: false, vertical: isNote)
+            }
+        }
     }
 }
 

--- a/app/dauphin/View/Loading/LaunchScreenView.swift
+++ b/app/dauphin/View/Loading/LaunchScreenView.swift
@@ -18,12 +18,13 @@ struct LaunchScreenView: View {
                 Image(systemName: "exclamationmark.triangle.fill").font(.system(size: 48))
                     .foregroundColor(.orange)
 
-                Text("Failed to load keys").font(.headline)
+                Text(LocalizedStringKey("launch.failedToLoadKeys")).font(.headline)
 
                 Text(errorMessage).font(.callout).foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
 
-                Button("Retry") { onRetry?() }.buttonStyle(.borderedProminent)
+                Button(LocalizedStringKey("launch.retry")) { onRetry?() }.buttonStyle(
+                    .borderedProminent)
             } else {
                 LottieView(animationFileName: "loading", loopMode: .loop).frame(
                     width: 200, height: 250)

--- a/app/dauphin/View/Other/Event/EventView.swift
+++ b/app/dauphin/View/Other/Event/EventView.swift
@@ -47,7 +47,7 @@ struct EventView: View {
                     }
                 }.padding(.vertical, 2)
             }
-        }.navigationTitle("校務行事曆").toolbar {
+        }.navigationTitle(LocalizedStringKey("校務行事曆")).toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
                     term = term == 1 ? 2 : 1
@@ -77,7 +77,7 @@ struct EventView: View {
     private static let fmt: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "yyyy M d EEEE"
-        f.locale = Locale(identifier: "zh_TW")
+        f.locale = .autoupdatingCurrent
         return f
     }()
 }

--- a/app/dauphin/View/Other/Library/LibraryView.swift
+++ b/app/dauphin/View/Other/Library/LibraryView.swift
@@ -10,6 +10,12 @@ import SwiftUI
 
 struct LibraryView: View {
     @ObservedObject var authViewModel: AuthViewModel
+
+    private var studentIDText: String {
+        String.localizedStringWithFormat(
+            NSLocalizedString("Student ID: %@", comment: ""), authViewModel.ssoStuNo)
+    }
+
     var body: some View {
         if authViewModel.isLoggedIn {
             VStack(spacing: 0) {
@@ -18,8 +24,7 @@ struct LibraryView: View {
                         Code39View("\(authViewModel.ssoStuNo)").cornerRadius(0).frame(
                             width: 296, height: 96)
                     }.padding(20).background(Color.white)
-                    Text("Student ID: \(authViewModel.ssoStuNo)").padding([.vertical], 8)
-                        .foregroundColor(.white)
+                    Text(studentIDText).padding([.vertical], 8).foregroundColor(.white)
                 }.background(Color.accentColor).cornerRadius(16).background(
                     RoundedRectangle(cornerRadius: 16).shadow(
                         color: Color.black.opacity(0.2), radius: 8, x: 0, y: 0))

--- a/app/dauphin/View/Setting/LibMainView.swift
+++ b/app/dauphin/View/Setting/LibMainView.swift
@@ -10,11 +10,16 @@ import SwiftUI
 struct LibMainView: View {
     @ObservedObject var viewModel: AuthViewModel
 
+    private var studentIDText: String {
+        String.localizedStringWithFormat(
+            NSLocalizedString("Your student ID is %@", comment: ""), viewModel.ssoStuNo)
+    }
+
     var body: some View {
         Group {
             if viewModel.isLoggedIn {
                 VStack(spacing: 20) {
-                    if viewModel.isLoggedIn { Text("Your student ID is \(viewModel.ssoStuNo)") }
+                    if viewModel.isLoggedIn { Text(studentIDText) }
                     Button(action: { viewModel.logout() }) {
                         Label("Logout", systemImage: "person.crop.circle")
                     }.buttonStyle(.borderedProminent).tint(.red)

--- a/app/dauphin/ViewModels/CourseViewModel.swift
+++ b/app/dauphin/ViewModels/CourseViewModel.swift
@@ -74,7 +74,7 @@ import SwiftUI
                     self.errorMessage = nil
                 } else {
                     Self.logger.debug("Network is unavailable")
-                    self.errorMessage = "No internet connection. Please check your network."
+                    self.errorMessage = String(localized: "course.error.noInternet")
                 }
             }
         }
@@ -92,7 +92,7 @@ import SwiftUI
         repo.clearCache()
         weekCourses = []
         isCacheEmpty = true
-        errorMessage = "Cache cleared. Please refresh to load courses."
+        errorMessage = String(localized: "course.cache.cleared")
     }
 
     func resetInitializationFlag() {
@@ -126,7 +126,7 @@ import SwiftUI
 
         guard isNetworkAvailable else {
             if weekCourses.isEmpty {
-                self.errorMessage = "No internet connection and no cached data available."
+                self.errorMessage = String(localized: "course.error.noInternetNoCache")
             }
             self.isRefreshing = false
             return
@@ -134,7 +134,7 @@ import SwiftUI
 
         hasPerformedInitialLoad = true
         self.isUpdatingCache = true
-        self.cacheUpdateMessage = "Updating course data..."
+        self.cacheUpdateMessage = String(localized: "course.cache.updating")
 
         do {
             guard let encryptedQuery = queryEncryptor.encryptedQuery(stdNo: stdNo) else {
@@ -148,16 +148,18 @@ import SwiftUI
             self.isUpdatingCache = false
             self.isRefreshing = false
             self.cacheUpdateMessage =
-                forceRefresh ? "Refreshed successfully" : "Course data updated"
+                forceRefresh
+                ? String(localized: "course.cache.refreshed")
+                : String(localized: "course.cache.updated")
             scheduleCacheMessageClear()
         } catch {
             self.isUpdatingCache = false
             self.isRefreshing = false
             self.cacheUpdateMessage = nil
             if self.weekCourses.isEmpty {
-                self.errorMessage = "Failed to fetch courses."
+                self.errorMessage = String(localized: "course.error.fetchFailed")
             } else if forceRefresh {
-                self.cacheUpdateMessage = "Refresh failed"
+                self.cacheUpdateMessage = String(localized: "course.cache.refreshFailed")
                 scheduleCacheMessageClear()
             }
             Self.logger.error("Fetch error: \(error.localizedDescription)")


### PR DESCRIPTION
## Summary
- localize key user-facing strings across app and widgets (course status/errors, launch/retry UI, student-ID text, and widget login/empty states)
- add and wire a localization catalog validator script (`scripts/check_localizations.py`) to CI
- run localization validation through `uv` locally and in CI (`astral-sh/setup-uv` + `uv run scripts/check_localizations.py`)

Fixes #51

## Testing
- `swift-format lint --configuration app/.swift-format --recursive .`
- `uv run scripts/check_localizations.py`
- `xcodebuild -project app/dauphin.xcodeproj -scheme dauphin -configuration Debug -destination 'id=EA0D1D18-8BA5-4248-AC5B-57799C06AB86' build`