### PR TITLE
feat(map): improve map sheet flow, list UX, and accessibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,3 +42,17 @@
 
 ## Security
 - Secrets live in `api.plist` and load through `KeyConstants`. Commit only sample values.
+
+## UI Design Policy
+As you design interfaces for Apple platforms, keep these principles in mind:
+- Hierarchy
+  - Establish a clear visual hierarchy where controls and interface elements elevate and distinguish the content beneath them.
+- Harmony
+  - Align with the concentric design of the hardware and software to create harmony between interface elements, system experiences, and devices.
+- Consistency
+  - Adopt platform conventions to maintain a consistent design that continuously adapts across window sizes and displays.
+
+- Prefer native iOS patterns for navigation, hierarchy, controls, spacing, and typography.
+- Accessibility is required by default: support Dynamic Type, VoiceOver labels/hints, sufficient contrast, and tappable target sizes.
+- Use SF Symbols and standard components when possible; deviations from HIG must be explicitly justified in PR notes.
+- Ensure user-facing UI strings are localized and consistent across supported locales.

--- a/app/dauphin/Utilities/Letter2Coordinate.swift
+++ b/app/dauphin/Utilities/Letter2Coordinate.swift
@@ -1,17 +1,16 @@
 import CoreLocation
 
 struct L2GData: Identifiable {
-    let id: UUID
     let code: String
     let name: String
     let coordinate: CLLocationCoordinate2D
 
-    init(id: UUID = UUID(), code: String, name: String, coordinate: CLLocationCoordinate2D) {
-        self.id = id
+    var id: String { code }
+
+    init(code: String, name: String, coordinate: CLLocationCoordinate2D) {
         self.code = code
         self.name = name
         self.coordinate = coordinate
-
     }
 }
 
@@ -66,6 +65,10 @@ let letterLocations: [String: L2GData] = [
 ]
 
 private let defaultCoord = CLLocationCoordinate2D(latitude: 25.0478, longitude: 121.5170)
+
+let campusLocations: [L2GData] = letterLocations.values.sorted { lhs, rhs in
+    lhs.code.localizedStandardCompare(rhs.code) == .orderedAscending
+}
 
 func letterToCoordinate(for letter: String) -> CLLocationCoordinate2D {
     letterLocations[letter]?.coordinate ?? defaultCoord

--- a/app/dauphin/View/Other/Map/LandMarkView.swift
+++ b/app/dauphin/View/Other/Map/LandMarkView.swift
@@ -3,85 +3,75 @@ import SwiftUI
 
 struct LandmarkView: View {
     let coordinate: CLLocationCoordinate2D
+    let didReturnToList: (() -> Void)?
+    @Environment(\.openURL) private var openURL
 
     @State private var lookAroundScene: MKLookAroundScene?
 
+    init(coordinate: CLLocationCoordinate2D, didReturnToList: (() -> Void)? = nil) {
+        self.coordinate = coordinate
+        self.didReturnToList = didReturnToList
+    }
+
     var body: some View {
-        VStack(spacing: 20) {
-            HStack {
-                Menu {
-                    appleMapsLink
-                    googleMapsLink
-                } label: {
-                    Map(
-                        initialPosition: .region(
-                            MKCoordinateRegion(
-                                center: coordinate,
-                                span: MKCoordinateSpan(latitudeDelta: 0.001, longitudeDelta: 0.001))
-                        )
-                    ) {
-                        Annotation("", coordinate: coordinate) {
-                            Image(systemName: "mappin").foregroundStyle(.red)
-                        }
-                    }.aspectRatio(1, contentMode: .fit).clipShape(RoundedRectangle(cornerRadius: 8))
-                }
-                // 明明有圖資為什麼不給我用？
-                LookAroundPreview(
-                    scene: $lookAroundScene, allowsNavigation: true, showsRoadLabels: true
-                ).aspectRatio(1, contentMode: .fit).clipShape(.rect(cornerRadius: 8)).task {
-                    let request = MKLookAroundSceneRequest(coordinate: coordinate)
-                    lookAroundScene = try? await request.scene
-                }
+        VStack(spacing: 16) {
+            HStack(spacing: 12) {
+                mapPreview
+                lookAroundPreview
             }
 
             Button {
                 let googleURLString =
                     "comgooglemaps://?daddr=\(coordinate.latitude),\(coordinate.longitude)&directionsmode=driving"
-                if let googleURL = URL(string: googleURLString),
-                    UIApplication.shared.canOpenURL(googleURL)
-                {
-                    // 開啟 Google Maps 導航
-                    UIApplication.shared.open(googleURL)
+                if let googleURL = URL(string: googleURLString) {
+                    openURL(googleURL) { accepted in if !accepted { openAppleDirections() } }
                 } else {
-                    // fallback: 使用 Apple Maps 導航
-                    let placemark = MKPlacemark(coordinate: coordinate)
-                    let mapItem = MKMapItem(placemark: placemark)
-                    //mapItem.name = name
-                    mapItem.openInMaps(launchOptions: [
-                        MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving
-                    ])
+                    openAppleDirections()
                 }
             } label: {
-                VStack(alignment: .leading) {
-                    Label {
-                        VStack(alignment: .leading) { Text("Open in Maps") }
-                    } icon: {
-                        Image(
-                            systemName:
-                                "point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath.fill"
-                        )
-                    }
-                }
+                Label(
+                    "Open in Maps",
+                    systemImage:
+                        "point.topright.arrow.triangle.backward.to.point.bottomleft.scurvepath.fill"
+                ).frame(maxWidth: .infinity)
+            }.buttonStyle(.borderedProminent).accessibilityIdentifier("map.action.directions")
+
+            if let didReturnToList {
+                Button(action: didReturnToList) {
+                    Label("Return to List", systemImage: "list.bullet").frame(maxWidth: .infinity)
+                }.buttonStyle(.bordered).accessibilityIdentifier("map.action.returnList")
             }
         }
     }
 
-    private var appleMapsLink: some View {
-        Button {
-            let placemark = MKPlacemark(coordinate: coordinate)
-            let mapItem = MKMapItem(placemark: placemark)
-            //mapItem.name = name
-            mapItem.openInMaps()
-        } label: {
-            Label("Open in Apple Maps", systemImage: "map")
-        }
+    private var mapPreview: some View {
+        Map(
+            initialPosition: .region(
+                MKCoordinateRegion(
+                    center: coordinate,
+                    span: MKCoordinateSpan(latitudeDelta: 0.001, longitudeDelta: 0.001)))
+        ) {
+            Annotation("", coordinate: coordinate) {
+                Image(systemName: "mappin").foregroundStyle(.red).accessibilityHidden(true)
+            }
+        }.aspectRatio(1, contentMode: .fit).clipShape(RoundedRectangle(cornerRadius: 12))
+            .accessibilityLabel(Text("Campus Map"))
     }
 
-    private var googleMapsLink: some View {
-        let urlString = "comgooglemaps://?q=\(coordinate.latitude),\(coordinate.longitude)"
-        guard let url = URL(string: urlString) else { return AnyView(EmptyView()) }
-        return AnyView(
-            Link(destination: url) { Label("Open in Google Maps", systemImage: "globe") })
+    private var lookAroundPreview: some View {
+        LookAroundPreview(scene: $lookAroundScene, allowsNavigation: true, showsRoadLabels: true)
+            .aspectRatio(1, contentMode: .fit).clipShape(.rect(cornerRadius: 12)).task {
+                let request = MKLookAroundSceneRequest(coordinate: coordinate)
+                lookAroundScene = try? await request.scene
+            }
+    }
+
+    private func openAppleDirections() {
+        let placemark = MKPlacemark(coordinate: coordinate)
+        let mapItem = MKMapItem(placemark: placemark)
+        mapItem.openInMaps(launchOptions: [
+            MKLaunchOptionsDirectionsModeKey: MKLaunchOptionsDirectionsModeDriving
+        ])
     }
 }
 

--- a/app/dauphin/View/Other/Map/LocationListView.swift
+++ b/app/dauphin/View/Other/Map/LocationListView.swift
@@ -29,7 +29,7 @@ struct LocationListView: View {
                             .tertiary)
                     }.padding(2)
                 }.accessibilityLabel(Text("\(loc.name) \(loc.code)")).accessibilityHint(
-                    Text("Open in Maps")
+                    Text("Show location details")
                 ).accessibilityIdentifier("map.location.\(loc.code)")
             }.navigationTitle("Locations").navigationBarTitleDisplayMode(.inline).listStyle(.plain)
                 .searchable(text: $searchText).toolbar {

--- a/app/dauphin/View/Other/Map/LocationListView.swift
+++ b/app/dauphin/View/Other/Map/LocationListView.swift
@@ -1,23 +1,44 @@
-import MapKit
 import SwiftUI
 
 struct LocationListView: View {
     let locations: [L2GData]
+    let didClose: () -> Void
     let didSelect: (L2GData) -> Void
+    @State private var searchText = ""
+
+    private var filteredLocations: [L2GData] {
+        guard !searchText.isEmpty else { return locations }
+        return locations.filter {
+            $0.name.localizedCaseInsensitiveContains(searchText)
+                || $0.code.localizedCaseInsensitiveContains(searchText)
+        }
+    }
 
     var body: some View {
         NavigationStack {
-            List(locations, id: \.id) { loc in
-                HStack {
-                    Image(systemName: "building.columns.circle.fill").font(.title)
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(loc.name).font(.title3)
-                        Text(loc.code).font(.callout).fontWeight(.thin)
-                    }
-                }.padding(2).onTapGesture {
+            List(filteredLocations, id: \.id) { loc in
+                Button {
                     withAnimation(.easeInOut(duration: 0.2)) { didSelect(loc) }
+                } label: {
+                    HStack {
+                        Image(systemName: "building.columns.circle.fill").font(.title3)
+                            .foregroundStyle(.tint)
+                        Text("\(loc.name) \(loc.code)").font(.headline)
+                        Spacer()
+                        Image(systemName: "chevron.right").font(.footnote).foregroundStyle(
+                            .tertiary)
+                    }.padding(2)
+                }.accessibilityLabel(Text("\(loc.name) \(loc.code)")).accessibilityHint(
+                    Text("Open in Maps")
+                ).accessibilityIdentifier("map.location.\(loc.code)")
+            }.navigationTitle("Locations").navigationBarTitleDisplayMode(.inline).listStyle(.plain)
+                .searchable(text: $searchText).toolbar {
+                    ToolbarItem(placement: .topBarTrailing) {
+                        Button(action: didClose) { Image(systemName: "xmark") }.accessibilityLabel(
+                            Text("Close")
+                        ).accessibilityIdentifier("map.list.close")
+                    }
                 }
-            }.navigationTitle("Locations")
         }
     }
 }
@@ -25,7 +46,5 @@ struct LocationListView: View {
 #Preview {
     @Previewable @State var selected: L2GData? = nil
 
-    return LocationListView(
-        locations: Array(letterLocations.values).sorted { $0.name < $1.name },
-        didSelect: { loc in selected = loc })
+    LocationListView(locations: campusLocations, didClose: {}, didSelect: { loc in selected = loc })
 }

--- a/app/dauphin/View/Other/Map/MapView.swift
+++ b/app/dauphin/View/Other/Map/MapView.swift
@@ -19,18 +19,14 @@ struct MapView: View {
 
                 Annotation(location.name, coordinate: location.coordinate, anchor: .bottom) {
                     Button {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            if selectedLocation == nil { overviewPosition = position }
-                            shouldRestoreOverviewOnDetailDismiss = true
-                            selectedLocation = location
-                            position = focusedPosition(for: location)
-                        }
+                        shouldRestoreOverviewOnDetailDismiss = true
+                        selectLocation(location)
                     } label: {
                         Image(systemName: "mappin.circle.fill").font(isSelected ? .title : .title2)
                             .foregroundStyle(isSelected ? .red : .secondary).shadow(
                                 radius: isSelected ? 3 : 1)
                     }.accessibilityLabel(Text("\(location.name) \(location.code)"))
-                        .accessibilityHint(Text("Open in Maps")).accessibilityIdentifier(
+                        .accessibilityHint(Text("Show location details")).accessibilityIdentifier(
                             "map.annotation.\(location.code)"
                         ).buttonStyle(.plain)
                 }

--- a/app/dauphin/View/Other/Map/MapView.swift
+++ b/app/dauphin/View/Other/Map/MapView.swift
@@ -6,61 +6,90 @@ struct MapView: View {
         .init(
             centerCoordinate: .init(latitude: 25.17553, longitude: 121.45063), distance: 1600,
             heading: 90, pitch: 35))
-    @State private var lookAroundScene: MKLookAroundScene?
     @State private var selectedLocation: L2GData?
-    @State private var isSheetPresented = true  // 無選中時顯示列表用
+    @State private var overviewPosition: MapCameraPosition?
+    @State private var isLocationListPresented = false
+    @State private var detailSheetDetent: PresentationDetent = .fraction(0.39)
+    @State private var shouldRestoreOverviewOnDetailDismiss = true
 
     var body: some View {
-        VStack(spacing: 8) {
-            Map(position: $position) {
-                ForEach(Array(letterLocations.values), id: \.id) { location in
-                    let isSelected = selectedLocation?.id == location.id
+        Map(position: $position) {
+            ForEach(campusLocations) { location in
+                let isSelected = selectedLocation?.id == location.id
 
-                    Annotation(location.name, coordinate: location.coordinate, anchor: .bottom) {
-                        Button {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                selectedLocation = location
-                                isSheetPresented = true
-                            }
-                        } label: {
-                            ZStack {
-                                Circle().fill(Color.white).scaleEffect(
-                                    isSelected ? 5.0 : 1.0, anchor: .bottom
-                                ).animation(.easeInOut(duration: 0.2), value: isSelected)
-
-                                Image(systemName: "mappin.circle.fill").font(.title2)
-                                    .foregroundStyle(.red).scaleEffect(
-                                        isSelected ? 5.0 : 1.0, anchor: .bottom
-                                    ).animation(.easeInOut(duration: 0.2), value: isSelected)
-                            }
-                        }.buttonStyle(.plain)
-                    }
+                Annotation(location.name, coordinate: location.coordinate, anchor: .bottom) {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            if selectedLocation == nil { overviewPosition = position }
+                            shouldRestoreOverviewOnDetailDismiss = true
+                            selectedLocation = location
+                            position = focusedPosition(for: location)
+                        }
+                    } label: {
+                        Image(systemName: "mappin.circle.fill").font(isSelected ? .title : .title2)
+                            .foregroundStyle(isSelected ? .red : .secondary).shadow(
+                                radius: isSelected ? 3 : 1)
+                    }.accessibilityLabel(Text("\(location.name) \(location.code)"))
+                        .accessibilityHint(Text("Open in Maps")).accessibilityIdentifier(
+                            "map.annotation.\(location.code)"
+                        ).buttonStyle(.plain)
                 }
-            }.mapStyle(.standard).mapControls {
-                MapCompass()
-                MapPitchToggle()
-                MapScaleView()
-            }.sheet(isPresented: $isSheetPresented) {
-                Group {
-                    if let location = selectedLocation {
-                        MarkerSheetView(location: location)
-                    } else {
-                        LocationListView(
-                            locations: Array(letterLocations.values).sorted { $0.name < $1.name },
-                            didSelect: { loc in selectedLocation = loc })
-                    }
-                }.presentationDetents([.fraction(0.5), .medium]).presentationDragIndicator(.visible)
-            }.onAppear {
-                isSheetPresented = true  // 初次進入就顯示清單
-                Task { await loadLookAround() }
             }
+        }.mapStyle(.standard).mapControls {
+            MapCompass()
+            MapPitchToggle()
+            MapScaleView()
+        }.safeAreaInset(edge: .bottom) {
+            HStack {
+                Spacer()
+                Button {
+                    isLocationListPresented = true
+                } label: {
+                    Label("Locations", systemImage: "list.bullet")
+                }.buttonStyle(.borderedProminent).padding(.horizontal, 16).padding(.bottom, 12)
+            }
+        }.sheet(item: $selectedLocation, onDismiss: restoreOverviewCamera) { location in
+            MarkerSheetView(
+                location: location, didClearSelection: { selectedLocation = nil },
+                didReturnToList: returnToLocationList
+            ).presentationDetents([.fraction(0.39), .medium], selection: $detailSheetDetent)
+                .presentationDragIndicator(.hidden)
+        }.sheet(isPresented: $isLocationListPresented) {
+            LocationListView(
+                locations: campusLocations, didClose: { isLocationListPresented = false },
+                didSelect: { location in
+                    isLocationListPresented = false
+                    selectLocation(location)
+                }
+            ).presentationDragIndicator(.hidden)
         }
     }
 
-    private func loadLookAround() async {
-        let coord = CLLocationCoordinate2D(latitude: 25.033968, longitude: 121.564468)
-        let request = MKLookAroundSceneRequest(coordinate: coord)
-        self.lookAroundScene = try? await request.scene
+    private func selectLocation(_ location: L2GData) {
+        withAnimation(.easeInOut(duration: 0.2)) {
+            if selectedLocation == nil { overviewPosition = position }
+            detailSheetDetent = .fraction(0.39)
+            selectedLocation = location
+            position = focusedPosition(for: location)
+        }
+    }
+
+    private func focusedPosition(for location: L2GData) -> MapCameraPosition {
+        .camera(.init(centerCoordinate: location.coordinate, distance: 500, heading: 0, pitch: 35))
+    }
+
+    private func restoreOverviewCamera() {
+        if shouldRestoreOverviewOnDetailDismiss, let overviewPosition {
+            withAnimation(.easeInOut(duration: 0.2)) { position = overviewPosition }
+        }
+        shouldRestoreOverviewOnDetailDismiss = true
+        self.overviewPosition = nil
+    }
+
+    private func returnToLocationList() {
+        shouldRestoreOverviewOnDetailDismiss = false
+        selectedLocation = nil
+        isLocationListPresented = true
     }
 }
 

--- a/app/dauphin/View/Other/Map/MarkerSheetView.swift
+++ b/app/dauphin/View/Other/Map/MarkerSheetView.swift
@@ -3,15 +3,24 @@ import SwiftUI
 
 struct MarkerSheetView: View {
     let location: L2GData
+    let didClearSelection: () -> Void
+    let didReturnToList: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text(location.name).font(.title2).fontWeight(.semibold).frame(
-                maxWidth: .infinity, alignment: .leading)
-            Text(location.code).font(.title3).fontWeight(.thin)
-
-            LandmarkView(coordinate: location.coordinate)
-        }.padding(24)
+        NavigationStack {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text(location.code).font(.subheadline).foregroundStyle(.secondary)
+                    LandmarkView(coordinate: location.coordinate, didReturnToList: didReturnToList)
+                }.padding(.horizontal, 24).padding(.top, 12)
+            }.navigationTitle(location.name).navigationBarTitleDisplayMode(.inline).toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(action: didClearSelection) { Image(systemName: "xmark") }
+                        .accessibilityLabel(Text("Close")).accessibilityIdentifier(
+                            "map.detail.close")
+                }
+            }
+        }.accessibilityIdentifier("map.markerSheet.\(location.code)")
     }
 }
 
@@ -19,5 +28,6 @@ struct MarkerSheetView: View {
     MarkerSheetView(
         location: L2GData(
             code: "A", name: "書卷廣場",
-            coordinate: CLLocationCoordinate2D(latitude: 25.17553, longitude: 121.45063)))
+            coordinate: CLLocationCoordinate2D(latitude: 25.17553, longitude: 121.45063)),
+        didClearSelection: {}, didReturnToList: {})
 }


### PR DESCRIPTION
## Summary
- redesign the map interaction flow so marker selection opens a detail sheet, restores map overview on dismiss, and supports returning to the location list from detail
- make location data deterministic by using stable location ids and a shared sorted `campusLocations` source for annotations and list rendering
- improve map/list accessibility and interaction semantics with explicit identifiers, button-based list rows, searchable location list, and inline list title behavior
- refine detail/list sheet presentation (`.fraction(0.39)` + hidden drag indicator) and align map action styling, including non-prominent `Return to List`
- add a repository UI policy in `AGENTS.md` requiring Apple HIG-aligned UI design updates

## Validation
- `swift-format lint --configuration app/.swift-format --recursive .`
- `xcodebuild -project app/dauphin.xcodeproj -scheme "dauphin" -configuration Debug -destination 'generic/platform=iOS Simulator' build`
- manual simulator verification: opened map, entered Locations list, selected `工學大樓 E`, and returned to list

Closes #52