### PR TITLE
refactor(courses): redesign schema/parser and add language toggles

### DIFF
--- a/app/CoursesWidget/CoursesWidget.swift
+++ b/app/CoursesWidget/CoursesWidget.swift
@@ -21,14 +21,23 @@ struct Provider: TimelineProvider {
     // MARK: - Placeholder
 
     func placeholder(in _: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), ssoStuNo: "", courses: [], today: 0)
+        SimpleEntry(date: Date(), ssoStuNo: "", courses: [], today: 0, showEnglishCourseName: false)
     }
 
     // MARK: - Snapshot
     func getSnapshot(in _: Context, completion: @escaping (SimpleEntry) -> Void) {
         let now = Date()
+        let showEnglishCourseName = loadShowEnglishCourseNamePreference()
         guard let stdNo = getSsoStuNo() else {
-            return completion(SimpleEntry(date: now, ssoStuNo: "", courses: [], today: 0))
+            return completion(
+                SimpleEntry(
+                    date: now,
+                    ssoStuNo: "",
+                    courses: [],
+                    today: 0,
+                    showEnglishCourseName: showEnglishCourseName
+                )
+            )
         }
 
         let cached = loadCoursesFromCache() ?? []
@@ -39,12 +48,16 @@ struct Provider: TimelineProvider {
         completion(
             SimpleEntry(
                 date: now, ssoStuNo: stdNo, courses: service.nextUp(from: cached, now: now),
-                today: cached.filter { $0.weekday == today }.count))
+                today: cached.filter { $0.weekday == today }.count,
+                showEnglishCourseName: showEnglishCourseName
+            )
+        )
     }
 
     // MARK: - Timeline
     func getTimeline(in _: Context, completion: @escaping (Timeline<SimpleEntry>) -> Void) {
         let now = Date()
+        let showEnglishCourseName = loadShowEnglishCourseNamePreference()
         let refresh =
             Calendar.current.date(byAdding: .minute, value: 15, to: now)
             ?? now.addingTimeInterval(900)
@@ -52,7 +65,15 @@ struct Provider: TimelineProvider {
         guard let stdNo = getSsoStuNo() else {
             return completion(
                 Timeline(
-                    entries: [SimpleEntry(date: now, ssoStuNo: "", courses: [], today: 0)],
+                    entries: [
+                        SimpleEntry(
+                            date: now,
+                            ssoStuNo: "",
+                            courses: [],
+                            today: 0,
+                            showEnglishCourseName: showEnglishCourseName
+                        )
+                    ],
                     policy: .after(refresh)))
         }
 
@@ -61,7 +82,8 @@ struct Provider: TimelineProvider {
         let today = ((Calendar.current.component(.weekday, from: now) + 5) % 7) + 1  // 1=Mon…7=Sun
         let entry = SimpleEntry(
             date: now, ssoStuNo: stdNo, courses: svc.nextUp(from: cached, now: now),
-            today: cached.lazy.filter { $0.weekday == today }.count)
+            today: cached.lazy.filter { $0.weekday == today }.count,
+            showEnglishCourseName: showEnglishCourseName)
 
         completion(Timeline(entries: [entry], policy: .after(refresh)))
     }
@@ -102,6 +124,16 @@ struct Provider: TimelineProvider {
             return nil
         }
     }
+
+    private func loadShowEnglishCourseNamePreference() -> Bool {
+        guard let defaults = UserDefaults(suiteName: Constants.appGroupSuiteName) else {
+            return Course.defaultShowEnglishCourseName()
+        }
+        guard defaults.object(forKey: Constants.showEnglishCourseName) != nil else {
+            return Course.defaultShowEnglishCourseName()
+        }
+        return defaults.bool(forKey: Constants.showEnglishCourseName)
+    }
 }
 struct CoursesNextUpWidgetEntryView: View {
     @Environment(\.colorScheme) var colorScheme
@@ -123,6 +155,7 @@ struct SimpleEntry: TimelineEntry {
     let ssoStuNo: String
     let courses: [Course]
     let today: Int
+    let showEnglishCourseName: Bool
 }
 
 struct CoursesNextUpWidget: Widget {

--- a/app/CoursesWidget/CoursesWidget.swift
+++ b/app/CoursesWidget/CoursesWidget.swift
@@ -187,7 +187,11 @@ struct CoursesNextUpWidget: Widget {
     var body: some WidgetConfiguration {
         StaticConfiguration(kind: kind, provider: Provider()) { entry in
             CoursesNextUpWidgetEntryView(entry: entry)
-        }.configurationDisplayName("Next Up").description("顯示下一堂課").supportedFamilies([
+        }.configurationDisplayName(
+            String(localized: "widget.courses.displayName")
+        ).description(
+            String(localized: "widget.courses.description")
+        ).supportedFamilies([
             .systemSmall, .accessoryRectangular,
         ])
     }

--- a/app/CoursesWidget/CoursesWidget.swift
+++ b/app/CoursesWidget/CoursesWidget.swift
@@ -21,13 +21,20 @@ struct Provider: TimelineProvider {
     // MARK: - Placeholder
 
     func placeholder(in _: Context) -> SimpleEntry {
-        SimpleEntry(date: Date(), ssoStuNo: "", courses: [], today: 0, showEnglishCourseName: false)
+        SimpleEntry(
+            date: Date(),
+            ssoStuNo: "",
+            courses: [],
+            today: 0,
+            showEnglishCourseName: false,
+            showEnglishTeacherName: false)
     }
 
     // MARK: - Snapshot
     func getSnapshot(in _: Context, completion: @escaping (SimpleEntry) -> Void) {
         let now = Date()
         let showEnglishCourseName = loadShowEnglishCourseNamePreference()
+        let showEnglishTeacherName = loadShowEnglishTeacherNamePreference()
         guard let stdNo = getSsoStuNo() else {
             return completion(
                 SimpleEntry(
@@ -35,7 +42,8 @@ struct Provider: TimelineProvider {
                     ssoStuNo: "",
                     courses: [],
                     today: 0,
-                    showEnglishCourseName: showEnglishCourseName
+                    showEnglishCourseName: showEnglishCourseName,
+                    showEnglishTeacherName: showEnglishTeacherName
                 )
             )
         }
@@ -49,7 +57,8 @@ struct Provider: TimelineProvider {
             SimpleEntry(
                 date: now, ssoStuNo: stdNo, courses: service.nextUp(from: cached, now: now),
                 today: cached.filter { $0.weekday == today }.count,
-                showEnglishCourseName: showEnglishCourseName
+                showEnglishCourseName: showEnglishCourseName,
+                showEnglishTeacherName: showEnglishTeacherName
             )
         )
     }
@@ -58,6 +67,7 @@ struct Provider: TimelineProvider {
     func getTimeline(in _: Context, completion: @escaping (Timeline<SimpleEntry>) -> Void) {
         let now = Date()
         let showEnglishCourseName = loadShowEnglishCourseNamePreference()
+        let showEnglishTeacherName = loadShowEnglishTeacherNamePreference()
         let refresh =
             Calendar.current.date(byAdding: .minute, value: 15, to: now)
             ?? now.addingTimeInterval(900)
@@ -71,7 +81,8 @@ struct Provider: TimelineProvider {
                             ssoStuNo: "",
                             courses: [],
                             today: 0,
-                            showEnglishCourseName: showEnglishCourseName
+                            showEnglishCourseName: showEnglishCourseName,
+                            showEnglishTeacherName: showEnglishTeacherName
                         )
                     ],
                     policy: .after(refresh)))
@@ -83,7 +94,8 @@ struct Provider: TimelineProvider {
         let entry = SimpleEntry(
             date: now, ssoStuNo: stdNo, courses: svc.nextUp(from: cached, now: now),
             today: cached.lazy.filter { $0.weekday == today }.count,
-            showEnglishCourseName: showEnglishCourseName)
+            showEnglishCourseName: showEnglishCourseName,
+            showEnglishTeacherName: showEnglishTeacherName)
 
         completion(Timeline(entries: [entry], policy: .after(refresh)))
     }
@@ -134,6 +146,16 @@ struct Provider: TimelineProvider {
         }
         return defaults.bool(forKey: Constants.showEnglishCourseName)
     }
+
+    private func loadShowEnglishTeacherNamePreference() -> Bool {
+        guard let defaults = UserDefaults(suiteName: Constants.appGroupSuiteName) else {
+            return Course.defaultShowEnglishTeacherName()
+        }
+        guard defaults.object(forKey: Constants.showEnglishTeacherName) != nil else {
+            return Course.defaultShowEnglishTeacherName()
+        }
+        return defaults.bool(forKey: Constants.showEnglishTeacherName)
+    }
 }
 struct CoursesNextUpWidgetEntryView: View {
     @Environment(\.colorScheme) var colorScheme
@@ -156,6 +178,7 @@ struct SimpleEntry: TimelineEntry {
     let courses: [Course]
     let today: Int
     let showEnglishCourseName: Bool
+    let showEnglishTeacherName: Bool
 }
 
 struct CoursesNextUpWidget: Widget {

--- a/app/CoursesWidget/CoursesWidget.swift
+++ b/app/CoursesWidget/CoursesWidget.swift
@@ -9,6 +9,11 @@ import SwiftUI
 import WidgetKit
 import os
 
+private struct WidgetCourseCachePayloadV2: Decodable {
+    let version: Int
+    let courses: [Course]
+}
+
 struct Provider: TimelineProvider {
     private static let logger = Logger(
         subsystem: Constants.loggerSubsystem, category: "CoursesWidget")
@@ -86,6 +91,11 @@ struct Provider: TimelineProvider {
         guard let data = defaults.data(forKey: Constants.courses) else { return nil }
         let decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .iso8601
+        if let payload = try? decoder.decode(WidgetCourseCachePayloadV2.self, from: data),
+            payload.version == 2
+        {
+            return payload.courses
+        }
         do { return try decoder.decode([Course].self, from: data) } catch {
             Provider.logger.error(
                 "Failed to decode cached courses: \(String(describing: error), privacy: .private)")

--- a/app/CoursesWidget/Views/NextUpLockScreenView.swift
+++ b/app/CoursesWidget/Views/NextUpLockScreenView.swift
@@ -40,6 +40,12 @@ struct CoursesNextUpViewLockScreenView: View {
                             "\(formatTime(entry.courses[0].startTime)) - \(formatTime(entry.courses[0].endTime))"
                         ).font(.system(size: 12))
 
+                        Text(
+                            entry.courses[0].displayTeacher(
+                                showEnglish: entry.showEnglishTeacherName
+                            )
+                        ).font(.system(size: 11)).lineLimit(1)
+
                         HStack {
                             HStack(spacing: 0) {
                                 Image(systemName: "location.circle").resizable().frame(
@@ -78,11 +84,11 @@ struct CoursesNextUpViewLockScreenView: View {
 #Preview(as: .accessoryRectangular) { CoursesNextUpWidget() } timeline: {
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789", courses: mockData, today: mockData.count,
-        showEnglishCourseName: false)
+        showEnglishCourseName: false, showEnglishTeacherName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "", courses: mockData, today: mockData.count,
-        showEnglishCourseName: false)
+        showEnglishCourseName: false, showEnglishTeacherName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789",
@@ -90,6 +96,6 @@ struct CoursesNextUpViewLockScreenView: View {
             from: mockData,
             currentDate: Calendar.current.date(
                 from: DateComponents(year: 2025, month: 9, day: 27, hour: 22, minute: 0))!),
-        today: mockData.count, showEnglishCourseName: false)
+        today: mockData.count, showEnglishCourseName: false, showEnglishTeacherName: false)
 
 }

--- a/app/CoursesWidget/Views/NextUpLockScreenView.swift
+++ b/app/CoursesWidget/Views/NextUpLockScreenView.swift
@@ -5,6 +5,10 @@ struct CoursesNextUpViewLockScreenView: View {
     @Environment(\.colorScheme) var colorScheme
 
     var entry: Provider.Entry
+    private func courseNameFontSize(for course: Course) -> CGFloat {
+        course.isShowingEnglishName(showEnglish: entry.showEnglishCourseName) ? 13 : 15
+    }
+
     var body: some View {
         if entry.ssoStuNo.isEmpty {
             HStack(spacing: 10) {
@@ -32,9 +36,10 @@ struct CoursesNextUpViewLockScreenView: View {
                     Spacer()
 
                     VStack(alignment: .leading, spacing: 4) {
-                        Text(
-                            entry.courses[0].displayName(showEnglish: entry.showEnglishCourseName)
-                        ).font(.system(size: 15, weight: .bold))
+                        Text(entry.courses[0].displayName(showEnglish: entry.showEnglishCourseName))
+                            .font(
+                                .system(
+                                    size: courseNameFontSize(for: entry.courses[0]), weight: .bold))
 
                         Text(
                             "\(formatTime(entry.courses[0].startTime)) - \(formatTime(entry.courses[0].endTime))"
@@ -42,8 +47,7 @@ struct CoursesNextUpViewLockScreenView: View {
 
                         Text(
                             entry.courses[0].displayTeacher(
-                                showEnglish: entry.showEnglishTeacherName
-                            )
+                                showEnglish: entry.showEnglishTeacherName)
                         ).font(.system(size: 11)).lineLimit(1)
 
                         HStack {

--- a/app/CoursesWidget/Views/NextUpLockScreenView.swift
+++ b/app/CoursesWidget/Views/NextUpLockScreenView.swift
@@ -32,7 +32,9 @@ struct CoursesNextUpViewLockScreenView: View {
                     Spacer()
 
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("\(entry.courses[0].name)").font(.system(size: 15, weight: .bold))
+                        Text(
+                            entry.courses[0].displayName(showEnglish: entry.showEnglishCourseName)
+                        ).font(.system(size: 15, weight: .bold))
 
                         Text(
                             "\(formatTime(entry.courses[0].startTime)) - \(formatTime(entry.courses[0].endTime))"
@@ -74,9 +76,13 @@ struct CoursesNextUpViewLockScreenView: View {
 }
 
 #Preview(as: .accessoryRectangular) { CoursesNextUpWidget() } timeline: {
-    SimpleEntry(date: Date(), ssoStuNo: "123456789", courses: mockData, today: mockData.count)
+    SimpleEntry(
+        date: Date(), ssoStuNo: "123456789", courses: mockData, today: mockData.count,
+        showEnglishCourseName: false)
 
-    SimpleEntry(date: Date(), ssoStuNo: "", courses: mockData, today: mockData.count)
+    SimpleEntry(
+        date: Date(), ssoStuNo: "", courses: mockData, today: mockData.count,
+        showEnglishCourseName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789",
@@ -84,6 +90,6 @@ struct CoursesNextUpViewLockScreenView: View {
             from: mockData,
             currentDate: Calendar.current.date(
                 from: DateComponents(year: 2025, month: 9, day: 27, hour: 22, minute: 0))!),
-        today: mockData.count)
+        today: mockData.count, showEnglishCourseName: false)
 
 }

--- a/app/CoursesWidget/Views/NextUpLockScreenView.swift
+++ b/app/CoursesWidget/Views/NextUpLockScreenView.swift
@@ -11,7 +11,7 @@ struct CoursesNextUpViewLockScreenView: View {
                 Image(systemName: "person.text.rectangle.trianglebadge.exclamationmark.fill").font(
                     .system(size: 40, weight: .semibold))
 
-                Text(LocalizedStringKey("widget.notLoggedIn")).font(.caption).fontWeight(.medium)
+                Text(String(localized: "widget.notLoggedIn")).font(.caption).fontWeight(.medium)
             }.frame(maxWidth: .infinity, maxHeight: .infinity).containerBackground(for: .widget) {
                 Color(UIColor.systemBackground)
             }
@@ -20,7 +20,7 @@ struct CoursesNextUpViewLockScreenView: View {
                 HStack(spacing: 10) {
                     Image(systemName: "figure.wave").font(.system(size: 40, weight: .semibold))
 
-                    Text(LocalizedStringKey("widget.seeYouNextWeek")).font(.caption).fontWeight(
+                    Text(String(localized: "widget.seeYouNextWeek")).font(.caption).fontWeight(
                         .medium)
                 }.frame(maxWidth: .infinity, maxHeight: .infinity).containerBackground(for: .widget)
                 { Color(UIColor.systemBackground) }

--- a/app/CoursesWidget/Views/NextUpSmallView.swift
+++ b/app/CoursesWidget/Views/NextUpSmallView.swift
@@ -66,6 +66,11 @@ struct CoursesNextUpSmallView: View {
                             Text(
                                 "\(formatTime(entry.courses[0].startTime)) - \(formatTime(entry.courses[0].endTime))"
                             ).font(.footnote).foregroundColor(.secondary)
+                            Text(
+                                entry.courses[0].displayTeacher(
+                                    showEnglish: entry.showEnglishTeacherName
+                                )
+                            ).lineLimit(1).font(.caption2).foregroundColor(.secondary)
                         }
 
                         HStack(spacing: 3) {
@@ -105,6 +110,11 @@ struct CoursesNextUpSmallView: View {
                                     Text(
                                         "\(formatTime(entry.courses[1].startTime)) - \(formatTime(entry.courses[1].endTime))"
                                     ).font(.footnote).foregroundColor(.secondary)
+                                    Text(
+                                        entry.courses[1].displayTeacher(
+                                            showEnglish: entry.showEnglishTeacherName
+                                        )
+                                    ).lineLimit(1).font(.caption2).foregroundColor(.secondary)
                                 }
 
                                 HStack(spacing: 3) {
@@ -138,6 +148,11 @@ struct CoursesNextUpSmallView: View {
                                     Text(
                                         "\(formatTime(entry.courses[1].startTime)) - \(formatTime(entry.courses[1].endTime))"
                                     ).font(.caption).foregroundColor(.secondary)
+                                    Text(
+                                        entry.courses[1].displayTeacher(
+                                            showEnglish: entry.showEnglishTeacherName
+                                        )
+                                    ).lineLimit(1).font(.caption2).foregroundColor(.secondary)
                                 }.padding(.bottom, 2).overlay(
                                     Capsule().fill(isSameDay ? Color.blue : Color.orange).frame(
                                         width: 4
@@ -158,7 +173,7 @@ struct CoursesNextUpSmallView: View {
 #Preview(as: .systemSmall) { CoursesNextUpWidget() } timeline: {
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789", courses: mockData, today: mockData.count,
-        showEnglishCourseName: false)
+        showEnglishCourseName: false, showEnglishTeacherName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789",
@@ -166,15 +181,15 @@ struct CoursesNextUpSmallView: View {
             from: mockData,
             currentDate: Calendar.current.date(
                 from: DateComponents(year: 2025, month: 9, day: 29, hour: 21, minute: 0))!),
-        today: mockData.count, showEnglishCourseName: false)
+        today: mockData.count, showEnglishCourseName: false, showEnglishTeacherName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789", courses: [mockData[0]], today: mockData.count,
-        showEnglishCourseName: false)
+        showEnglishCourseName: false, showEnglishTeacherName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "", courses: mockData, today: mockData.count,
-        showEnglishCourseName: false)
+        showEnglishCourseName: false, showEnglishTeacherName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789",
@@ -182,5 +197,5 @@ struct CoursesNextUpSmallView: View {
             from: mockData,
             currentDate: Calendar.current.date(
                 from: DateComponents(year: 2025, month: 9, day: 27, hour: 22, minute: 0))!),
-        today: mockData.count, showEnglishCourseName: false)
+        today: mockData.count, showEnglishCourseName: false, showEnglishTeacherName: false)
 }

--- a/app/CoursesWidget/Views/NextUpSmallView.swift
+++ b/app/CoursesWidget/Views/NextUpSmallView.swift
@@ -58,8 +58,11 @@ struct CoursesNextUpSmallView: View {
                     // First Event
                     VStack(alignment: .leading, spacing: 2) {
                         VStack(alignment: .leading, spacing: 0) {
-                            Text("\(entry.courses[0].name)").lineLimit(1).font(.subheadline)
-                                .foregroundColor(.primary)
+                            Text(
+                                entry.courses[0].displayName(
+                                    showEnglish: entry.showEnglishCourseName
+                                )
+                            ).lineLimit(1).font(.subheadline).foregroundColor(.primary)
                             Text(
                                 "\(formatTime(entry.courses[0].startTime)) - \(formatTime(entry.courses[0].endTime))"
                             ).font(.footnote).foregroundColor(.secondary)
@@ -94,8 +97,11 @@ struct CoursesNextUpSmallView: View {
                         if isSameDay {
                             VStack(alignment: .leading, spacing: 2) {
                                 VStack(alignment: .leading, spacing: 0) {
-                                    Text("\(entry.courses[1].name)").lineLimit(1).font(.subheadline)
-                                        .foregroundColor(.primary)
+                                    Text(
+                                        entry.courses[1].displayName(
+                                            showEnglish: entry.showEnglishCourseName
+                                        )
+                                    ).lineLimit(1).font(.subheadline).foregroundColor(.primary)
                                     Text(
                                         "\(formatTime(entry.courses[1].startTime)) - \(formatTime(entry.courses[1].endTime))"
                                     ).font(.footnote).foregroundColor(.secondary)
@@ -124,8 +130,11 @@ struct CoursesNextUpSmallView: View {
                                     .padding(.leading, -10)
 
                                 VStack(alignment: .leading, spacing: 0) {
-                                    Text("\(entry.courses[1].name)").font(.subheadline)
-                                        .foregroundColor(.primary).lineLimit(1)
+                                    Text(
+                                        entry.courses[1].displayName(
+                                            showEnglish: entry.showEnglishCourseName
+                                        )
+                                    ).font(.subheadline).foregroundColor(.primary).lineLimit(1)
                                     Text(
                                         "\(formatTime(entry.courses[1].startTime)) - \(formatTime(entry.courses[1].endTime))"
                                     ).font(.caption).foregroundColor(.secondary)
@@ -147,7 +156,9 @@ struct CoursesNextUpSmallView: View {
 }
 
 #Preview(as: .systemSmall) { CoursesNextUpWidget() } timeline: {
-    SimpleEntry(date: Date(), ssoStuNo: "123456789", courses: mockData, today: mockData.count)
+    SimpleEntry(
+        date: Date(), ssoStuNo: "123456789", courses: mockData, today: mockData.count,
+        showEnglishCourseName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789",
@@ -155,11 +166,15 @@ struct CoursesNextUpSmallView: View {
             from: mockData,
             currentDate: Calendar.current.date(
                 from: DateComponents(year: 2025, month: 9, day: 29, hour: 21, minute: 0))!),
-        today: mockData.count)
+        today: mockData.count, showEnglishCourseName: false)
 
-    SimpleEntry(date: Date(), ssoStuNo: "123456789", courses: [mockData[0]], today: mockData.count)
+    SimpleEntry(
+        date: Date(), ssoStuNo: "123456789", courses: [mockData[0]], today: mockData.count,
+        showEnglishCourseName: false)
 
-    SimpleEntry(date: Date(), ssoStuNo: "", courses: mockData, today: mockData.count)
+    SimpleEntry(
+        date: Date(), ssoStuNo: "", courses: mockData, today: mockData.count,
+        showEnglishCourseName: false)
 
     SimpleEntry(
         date: Date(), ssoStuNo: "123456789",
@@ -167,5 +182,5 @@ struct CoursesNextUpSmallView: View {
             from: mockData,
             currentDate: Calendar.current.date(
                 from: DateComponents(year: 2025, month: 9, day: 27, hour: 22, minute: 0))!),
-        today: mockData.count)
+        today: mockData.count, showEnglishCourseName: false)
 }

--- a/app/CoursesWidget/Views/NextUpSmallView.swift
+++ b/app/CoursesWidget/Views/NextUpSmallView.swift
@@ -34,6 +34,10 @@ struct CoursesNextUpSmallView: View {
         return formatter.weekdaySymbols
     }()
 
+    private func courseNameFontSize(for course: Course) -> CGFloat {
+        course.isShowingEnglishName(showEnglish: entry.showEnglishCourseName) ? 12 : 15
+    }
+
     var body: some View {
         if entry.ssoStuNo.isEmpty {
             VStack(spacing: 8) {
@@ -60,16 +64,18 @@ struct CoursesNextUpSmallView: View {
                         VStack(alignment: .leading, spacing: 0) {
                             Text(
                                 entry.courses[0].displayName(
-                                    showEnglish: entry.showEnglishCourseName
-                                )
-                            ).lineLimit(1).font(.subheadline).foregroundColor(.primary)
+                                    showEnglish: entry.showEnglishCourseName)
+                            ).lineLimit(1).font(
+                                .system(
+                                    size: courseNameFontSize(for: entry.courses[0]),
+                                    weight: .semibold)
+                            ).foregroundColor(.primary)
                             Text(
                                 "\(formatTime(entry.courses[0].startTime)) - \(formatTime(entry.courses[0].endTime))"
                             ).font(.footnote).foregroundColor(.secondary)
                             Text(
                                 entry.courses[0].displayTeacher(
-                                    showEnglish: entry.showEnglishTeacherName
-                                )
+                                    showEnglish: entry.showEnglishTeacherName)
                             ).lineLimit(1).font(.caption2).foregroundColor(.secondary)
                         }
 
@@ -104,16 +110,18 @@ struct CoursesNextUpSmallView: View {
                                 VStack(alignment: .leading, spacing: 0) {
                                     Text(
                                         entry.courses[1].displayName(
-                                            showEnglish: entry.showEnglishCourseName
-                                        )
-                                    ).lineLimit(1).font(.subheadline).foregroundColor(.primary)
+                                            showEnglish: entry.showEnglishCourseName)
+                                    ).lineLimit(1).font(
+                                        .system(
+                                            size: courseNameFontSize(for: entry.courses[1]),
+                                            weight: .semibold)
+                                    ).foregroundColor(.primary)
                                     Text(
                                         "\(formatTime(entry.courses[1].startTime)) - \(formatTime(entry.courses[1].endTime))"
                                     ).font(.footnote).foregroundColor(.secondary)
                                     Text(
                                         entry.courses[1].displayTeacher(
-                                            showEnglish: entry.showEnglishTeacherName
-                                        )
+                                            showEnglish: entry.showEnglishTeacherName)
                                     ).lineLimit(1).font(.caption2).foregroundColor(.secondary)
                                 }
 
@@ -142,16 +150,18 @@ struct CoursesNextUpSmallView: View {
                                 VStack(alignment: .leading, spacing: 0) {
                                     Text(
                                         entry.courses[1].displayName(
-                                            showEnglish: entry.showEnglishCourseName
-                                        )
-                                    ).font(.subheadline).foregroundColor(.primary).lineLimit(1)
+                                            showEnglish: entry.showEnglishCourseName)
+                                    ).font(
+                                        .system(
+                                            size: courseNameFontSize(for: entry.courses[1]),
+                                            weight: .semibold)
+                                    ).foregroundColor(.primary).lineLimit(1)
                                     Text(
                                         "\(formatTime(entry.courses[1].startTime)) - \(formatTime(entry.courses[1].endTime))"
                                     ).font(.caption).foregroundColor(.secondary)
                                     Text(
                                         entry.courses[1].displayTeacher(
-                                            showEnglish: entry.showEnglishTeacherName
-                                        )
+                                            showEnglish: entry.showEnglishTeacherName)
                                     ).lineLimit(1).font(.caption2).foregroundColor(.secondary)
                                 }.padding(.bottom, 2).overlay(
                                     Capsule().fill(isSameDay ? Color.blue : Color.orange).frame(

--- a/app/StdID/StdID.swift
+++ b/app/StdID/StdID.swift
@@ -53,8 +53,8 @@ struct StdIDEntryView: View {
                 VStack(spacing: 8) {
                     Image(systemName: "person.text.rectangle.trianglebadge.exclamationmark.fill")
                         .font(.system(size: 60, weight: .semibold))
-                    Text(LocalizedStringKey("widget.notLoggedIn")).font(.caption).fontWeight(
-                        .medium)
+                    Text(String(localized: "widget.notLoggedIn"))
+                        .font(.caption).fontWeight(.medium)
                 }.frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }.padding(12).foregroundStyle(.black).background(Color.white)

--- a/app/Tests/ModelsTests/CourseFormattingTests.swift
+++ b/app/Tests/ModelsTests/CourseFormattingTests.swift
@@ -35,6 +35,22 @@ import Testing
         #expect(course.displayName(showEnglish: true) == "LINEAR ALGEBRA")
         #expect(course.displayTeacher(showEnglish: false) == "Dr. Lin")
         #expect(course.displayTeacher(showEnglish: true) == "DR. LIN")
+
+        let noEnglish = Course(
+            name: "微積分",
+            enName: "   ",
+            room: "A101",
+            teacher: "王老師",
+            teacherEn: "",
+            time: "3, 4",
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(3600),
+            stdNo: "002",
+            weekday: 2
+        )
+
+        #expect(noEnglish.displayName(showEnglish: true) == "微積分")
+        #expect(noEnglish.displayTeacher(showEnglish: true) == "王老師")
     }
 
     @Test("default language rule only keeps Chinese for zh-Hant locales")

--- a/app/Tests/ModelsTests/CourseFormattingTests.swift
+++ b/app/Tests/ModelsTests/CourseFormattingTests.swift
@@ -15,4 +15,34 @@ import Testing
         let err = formatTime(nil)
         #expect(err == "ERROR")
     }
+
+    @Test("displayName prefers English when enabled and available")
+    func displayNamePrefersEnglishWhenEnabled() {
+        let course = Course(
+            name: "線性代數",
+            enName: "LINEAR ALGEBRA",
+            room: "B101",
+            teacher: "Dr. Lin",
+            teacherEn: "DR. LIN",
+            time: "2, 3",
+            startTime: Date(),
+            endTime: Date().addingTimeInterval(3600),
+            stdNo: "001",
+            weekday: 1
+        )
+
+        #expect(course.displayName(showEnglish: false) == "線性代數")
+        #expect(course.displayName(showEnglish: true) == "LINEAR ALGEBRA")
+        #expect(course.displayTeacher(showEnglish: false) == "Dr. Lin")
+        #expect(course.displayTeacher(showEnglish: true) == "DR. LIN")
+    }
+
+    @Test("default language rule only keeps Chinese for zh-Hant locales")
+    func defaultLanguageRule() {
+        #expect(Course.shouldShowEnglishCourseName(forPreferredLanguage: "en-US") == true)
+        #expect(Course.shouldShowEnglishCourseName(forPreferredLanguage: "ja-JP") == true)
+        #expect(Course.shouldShowEnglishCourseName(forPreferredLanguage: "zh-Hant-TW") == false)
+        #expect(Course.shouldShowEnglishCourseName(forPreferredLanguage: "zh-TW") == false)
+        #expect(Course.defaultShowEnglishTeacherName() == Course.defaultShowEnglishCourseName())
+    }
 }

--- a/app/Tests/ModelsTests/CourseFormattingTests.swift
+++ b/app/Tests/ModelsTests/CourseFormattingTests.swift
@@ -19,42 +19,28 @@ import Testing
     @Test("displayName prefers English when enabled and available")
     func displayNamePrefersEnglishWhenEnabled() {
         let course = Course(
-            name: "線性代數",
-            enName: "LINEAR ALGEBRA",
-            room: "B101",
-            teacher: "Dr. Lin",
-            teacherEn: "DR. LIN",
-            time: "2, 3",
-            startTime: Date(),
-            endTime: Date().addingTimeInterval(3600),
-            stdNo: "001",
-            weekday: 1
-        )
+            name: "線性代數", enName: "LINEAR ALGEBRA", room: "B101", teacher: "Dr. Lin",
+            teacherEn: "DR. LIN", time: "2, 3", startTime: Date(),
+            endTime: Date().addingTimeInterval(3600), stdNo: "001", weekday: 1)
 
         #expect(course.displayName(showEnglish: false) == "線性代數")
         #expect(course.displayName(showEnglish: true) == "LINEAR ALGEBRA")
+        #expect(course.isShowingEnglishName(showEnglish: true) == true)
+        #expect(course.isShowingEnglishName(showEnglish: false) == false)
         #expect(course.displayTeacher(showEnglish: false) == "Dr. Lin")
         #expect(course.displayTeacher(showEnglish: true) == "DR. LIN")
 
         let noEnglish = Course(
-            name: "微積分",
-            enName: "   ",
-            room: "A101",
-            teacher: "王老師",
-            teacherEn: "",
-            time: "3, 4",
-            startTime: Date(),
-            endTime: Date().addingTimeInterval(3600),
-            stdNo: "002",
-            weekday: 2
-        )
+            name: "微積分", enName: "   ", room: "A101", teacher: "王老師", teacherEn: "", time: "3, 4",
+            startTime: Date(), endTime: Date().addingTimeInterval(3600), stdNo: "002", weekday: 2)
 
         #expect(noEnglish.displayName(showEnglish: true) == "微積分")
+        #expect(noEnglish.isShowingEnglishName(showEnglish: true) == false)
         #expect(noEnglish.displayTeacher(showEnglish: true) == "王老師")
     }
 
-    @Test("default language rule only keeps Chinese for zh-Hant locales")
-    func defaultLanguageRule() {
+    @Test("default language rule only keeps Chinese for zh-Hant locales") func defaultLanguageRule()
+    {
         #expect(Course.shouldShowEnglishCourseName(forPreferredLanguage: "en-US") == true)
         #expect(Course.shouldShowEnglishCourseName(forPreferredLanguage: "ja-JP") == true)
         #expect(Course.shouldShowEnglishCourseName(forPreferredLanguage: "zh-Hant-TW") == false)

--- a/app/Tests/ModelsTests/CourseParserTests.swift
+++ b/app/Tests/ModelsTests/CourseParserTests.swift
@@ -102,8 +102,8 @@ import Testing
         #expect(courses[0].teachers == ["A", "B"])
     }
 
-    @Test("falls back to sess fields when timePlase is missing")
-    func fallsBackToSessFields() throws {
+    @Test("falls back to sess fields when timePlase is missing") func fallsBackToSessFields() throws
+    {
         let json = """
             {
               "stuelelist": [
@@ -133,8 +133,9 @@ import Testing
         #expect(courses[0].time == "6, 7")
     }
 
-    @Test("merges contiguous rows from cells fallback")
-    func mergesContiguousRowsFromCellsFallback() throws {
+    @Test("merges contiguous rows from cells fallback") func mergesContiguousRowsFromCellsFallback()
+        throws
+    {
         let json = """
             {
               "stuelelist": [],

--- a/app/Tests/ModelsTests/CourseParserTests.swift
+++ b/app/Tests/ModelsTests/CourseParserTests.swift
@@ -263,6 +263,7 @@ import Testing
         let course = try #require(courses.first)
         #expect(course.teacher == "張三")
         #expect(course.teacherEn == "CHANG SAN")
+        #expect(course.remark == nil)
         #expect(course.displayTeacher(showEnglish: true) == "CHANG SAN")
     }
 }

--- a/app/Tests/ModelsTests/CourseParserTests.swift
+++ b/app/Tests/ModelsTests/CourseParserTests.swift
@@ -48,8 +48,10 @@ import Testing
         #expect(course.sessionNumbers == [2, 4])
         #expect(course.weekday == 1)
         #expect(course.enName == "LINEAR ALGEBRA")
+        #expect(course.teacherEn == "DR. LIN")
         #expect(course.cosNo == "COS001")
         #expect(course.cosEleSeq == "0743")
+        #expect(course.remark == nil)
         #expect(course.startTime == Date(timeIntervalSince1970: 120))
         #expect(course.endTime == Date(timeIntervalSince1970: 270))
         let calendar = Calendar.current
@@ -231,5 +233,36 @@ import Testing
         let courses = try parser.parse(Data(json.utf8))
         let course = try #require(courses.first)
         #expect(course.name == "幸福的理性與感性(本科目為通識教育跨領域微學程課程,大學部學生均可選修)")
+    }
+
+    @Test("parses english teacher name from cells fallback")
+    func parsesEnglishTeacherNameFromCells() throws {
+        let json = """
+            {
+              "stuelelist": [],
+              "cells": [
+                {
+                  "weekno": "2",
+                  "sessno": "07",
+                  "ch_cos_name": "離散數學",
+                  "teach_name": "張三",
+                  "teach_name_en": "CHANG SAN",
+                  "seatno": "012",
+                  "room": "C101"
+                }
+              ]
+            }
+            """
+
+        let parser = DefaultCourseParser(
+            htmlStrip: { $0 },
+            sessionToStart: { Date(timeIntervalSince1970: TimeInterval($0 * 60)) },
+            sessionToEnd: { Date(timeIntervalSince1970: TimeInterval($0 * 60 + 30)) })
+
+        let courses = try parser.parse(Data(json.utf8))
+        let course = try #require(courses.first)
+        #expect(course.teacher == "張三")
+        #expect(course.teacherEn == "CHANG SAN")
+        #expect(course.displayTeacher(showEnglish: true) == "CHANG SAN")
     }
 }

--- a/app/Tests/ModelsTests/CourseParserTests.swift
+++ b/app/Tests/ModelsTests/CourseParserTests.swift
@@ -11,10 +11,15 @@ import Testing
               "stuelelist": [
                 {
                   "week": "1",
-                  "ch_cos_name": "<b>Linear Algebra</b>,extra",
+                  "ch_cos_name": "<b>線性代數</b>",
+                  "en_cos_name": "LINEAR ALGEBRA",
                   "teach_name": "<i>Dr. Lin</i>,x",
+                  "teach_name_en": "DR. LIN",
                   "room": "<span>B101</span>,foo",
                   "seat_no": "S123,foo",
+                  "cos_no": "COS001",
+                  "cos_ele_seq": "0743",
+                  "remark": "&nbsp;",
                   "note": "<p>Important</p>",
                   "timePlase": { "sesses": ["4", "2"] }
                 }
@@ -32,15 +37,32 @@ import Testing
         #expect(courses.count == 1)
 
         let course = try #require(courses.first)
-        #expect(course.name == "Linear Algebra")
+        #expect(course.name == "線性代數")
         #expect(course.teacher == "Dr. Lin")
+        #expect(course.teachers == ["Dr. Lin"])
         #expect(course.room == "B101")
         #expect(course.stdNo == "S123")
+        #expect(course.seatNo == "S123")
         #expect(course.note == "Important")
         #expect(course.time == "2, 4")
+        #expect(course.sessionNumbers == [2, 4])
         #expect(course.weekday == 1)
+        #expect(course.enName == "LINEAR ALGEBRA")
+        #expect(course.cosNo == "COS001")
+        #expect(course.cosEleSeq == "0743")
         #expect(course.startTime == Date(timeIntervalSince1970: 120))
         #expect(course.endTime == Date(timeIntervalSince1970: 270))
+        let calendar = Calendar.current
+        let expectedStartMinute =
+            calendar.component(.hour, from: course.startTime) * 60
+            + calendar.component(.minute, from: course.startTime)
+        let expectedEndMinute =
+            calendar.component(.hour, from: course.endTime) * 60
+            + calendar.component(.minute, from: course.endTime)
+        #expect(course.startMinuteOfDay == expectedStartMinute)
+        #expect(course.endMinuteOfDay == expectedEndMinute)
+        #expect(course.durationMinutes == max(0, expectedEndMinute - expectedStartMinute))
+        #expect(!course.id.isEmpty)
     }
 
     @Test("dedupes and merges teacher names") func dedupesAndMergesTeacherNames() throws {
@@ -77,6 +99,75 @@ import Testing
         let courses = try parser.parse(Data(json.utf8))
         #expect(courses.count == 1)
         #expect(courses[0].teacher == "A, B")
+        #expect(courses[0].teachers == ["A", "B"])
+    }
+
+    @Test("falls back to sess fields when timePlase is missing")
+    func fallsBackToSessFields() throws {
+        let json = """
+            {
+              "stuelelist": [
+                {
+                  "week": "3",
+                  "ch_cos_name": "Networks",
+                  "teach_name": "T",
+                  "room": "R",
+                  "seat_no": "S",
+                  "note": "",
+                  "sess1": "06",
+                  "sess2": "07",
+                  "sess3": "  "
+                }
+              ]
+            }
+            """
+
+        let parser = DefaultCourseParser(
+            htmlStrip: { $0 },
+            sessionToStart: { Date(timeIntervalSince1970: TimeInterval($0 * 60)) },
+            sessionToEnd: { Date(timeIntervalSince1970: TimeInterval($0 * 60 + 30)) })
+
+        let courses = try parser.parse(Data(json.utf8))
+        #expect(courses.count == 1)
+        #expect(courses[0].sessionNumbers == [6, 7])
+        #expect(courses[0].time == "6, 7")
+    }
+
+    @Test("merges contiguous rows from cells fallback")
+    func mergesContiguousRowsFromCellsFallback() throws {
+        let json = """
+            {
+              "stuelelist": [],
+              "cells": [
+                {
+                  "weekno": "2",
+                  "sessno": "07",
+                  "ch_cos_name": "Happiness",
+                  "teach_name": "A",
+                  "seatno": "003",
+                  "room": "L302"
+                },
+                {
+                  "weekno": "2",
+                  "sessno": "08",
+                  "ch_cos_name": "Happiness",
+                  "teach_name": "A",
+                  "seatno": "003",
+                  "room": "L302"
+                }
+              ]
+            }
+            """
+
+        let parser = DefaultCourseParser(
+            htmlStrip: { $0 },
+            sessionToStart: { Date(timeIntervalSince1970: TimeInterval($0 * 60)) },
+            sessionToEnd: { Date(timeIntervalSince1970: TimeInterval($0 * 60 + 30)) })
+
+        let courses = try parser.parse(Data(json.utf8))
+        #expect(courses.count == 1)
+        #expect(courses[0].sessionNumbers == [7, 8])
+        #expect(courses[0].time == "7, 8")
     }
 
     @Test("filters invalid weekday or session rows") func filtersInvalidRows() throws {
@@ -111,5 +202,33 @@ import Testing
 
         let courses = try parser.parse(Data(json.utf8))
         #expect(courses.isEmpty)
+    }
+
+    @Test("keeps full chinese course name without comma truncation")
+    func keepsFullChineseCourseName() throws {
+        let json = """
+            {
+              "stuelelist": [
+                {
+                  "week": "2",
+                  "ch_cos_name": "幸福的理性與感性(本科目為通識教育跨領域微學程課程,大學部學生均可選修)",
+                  "teach_name": "胡延薇",
+                  "room": "L302",
+                  "seat_no": "003",
+                  "note": "",
+                  "timePlase": { "sesses": ["07"] }
+                }
+              ]
+            }
+            """
+
+        let parser = DefaultCourseParser(
+            htmlStrip: { $0 },
+            sessionToStart: { Date(timeIntervalSince1970: TimeInterval($0 * 60)) },
+            sessionToEnd: { Date(timeIntervalSince1970: TimeInterval($0 * 60 + 30)) })
+
+        let courses = try parser.parse(Data(json.utf8))
+        let course = try #require(courses.first)
+        #expect(course.name == "幸福的理性與感性(本科目為通識教育跨領域微學程課程,大學部學生均可選修)")
     }
 }

--- a/app/Tests/ModelsTests/WidgetCacheDecodeTests.swift
+++ b/app/Tests/ModelsTests/WidgetCacheDecodeTests.swift
@@ -23,7 +23,7 @@ import Testing
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let data = try #require(defaults.data(forKey: key))
-        let decoded = widgetStyleDecodeCourses(data)
+        let decoded = decodeCoursesFromCacheData(data)
         let decodedCourses = try #require(decoded)
         #expect(decodedCourses == sample)
     }
@@ -31,12 +31,6 @@ import Testing
     @Test("widget-style decoder returns nil for invalid payload")
     func widgetStyleDecoderRejectsInvalidPayload() throws {
         let invalid = Data("not-json".utf8)
-        #expect(widgetStyleDecodeCourses(invalid) == nil)
-    }
-
-    private func widgetStyleDecodeCourses(_ data: Data) -> [dauphin.Course]? {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        return try? decoder.decode([dauphin.Course].self, from: data)
+        #expect(decodeCoursesFromCacheData(invalid) == nil)
     }
 }

--- a/app/dauphin.xcodeproj/project.pbxproj
+++ b/app/dauphin.xcodeproj/project.pbxproj
@@ -154,6 +154,7 @@
 		1857DB522E00273E008EFC8E /* Exceptions for "dauphin" folder in "CoursesWidgetExtension Beta" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Localizable.xcstrings,
 				Models/Course.swift,
 				Utilities/Constants.swift,
 				Utilities/Courses/CourseAPIClient.swift,
@@ -169,6 +170,7 @@
 		1857DB562E002754008EFC8E /* Exceptions for "dauphin" folder in "StdIDExtension Beta" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Localizable.xcstrings,
 				Models/Course.swift,
 				Utilities/Constants.swift,
 				Utilities/Courses/NextUpService.swift,
@@ -185,6 +187,7 @@
 		185C496E2CF6E97D00589C39 /* Exceptions for "dauphin" folder in "CoursesWidgetExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Localizable.xcstrings,
 				Models/Course.swift,
 				Utilities/Constants.swift,
 				Utilities/Courses/CourseAPIClient.swift,
@@ -221,6 +224,7 @@
 		18E8F2262DB6069800B2FB57 /* Exceptions for "dauphin" folder in "StdIDExtension" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				Localizable.xcstrings,
 				Models/Course.swift,
 				Utilities/Constants.swift,
 				Utilities/Courses/NextUpService.swift,

--- a/app/dauphin/Localizable.xcstrings
+++ b/app/dauphin/Localizable.xcstrings
@@ -980,6 +980,38 @@
         }
       }
     },
+    "widget.courses.description" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show your next class"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "顯示下一堂課"
+          }
+        }
+      }
+    },
+    "widget.courses.displayName" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next Up"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下一堂"
+          }
+        }
+      }
+    },
     "widget.seeYouNextWeek" : {
       "localizations" : {
         "en" : {

--- a/app/dauphin/Models/Course.swift
+++ b/app/dauphin/Models/Course.swift
@@ -15,6 +15,7 @@ struct Course: Identifiable, Hashable, Codable {
     var cosEleSeq: String?
     var room: String
     var teacher: String
+    var teacherEn: String?
     var teachers: [String]
     var time: String
     var sessionNumbers: [Int]
@@ -34,7 +35,8 @@ struct Course: Identifiable, Hashable, Codable {
 
     init(
         id: String? = nil, name: String, enName: String? = nil, cosNo: String? = nil,
-        cosEleSeq: String? = nil, room: String, teacher: String, teachers: [String]? = nil,
+        cosEleSeq: String? = nil, room: String, teacher: String, teacherEn: String? = nil,
+        teachers: [String]? = nil,
         time: String, sessionNumbers: [Int] = [], startTime: Date, endTime: Date, stdNo: String,
         weekday: Int, note: String = "", remark: String? = nil, startMinuteOfDay: Int? = nil,
         endMinuteOfDay: Int? = nil, durationMinutes: Int? = nil, sortKey: Int? = nil,
@@ -46,6 +48,7 @@ struct Course: Identifiable, Hashable, Codable {
         self.cosEleSeq = cosEleSeq
         self.room = room
         self.teacher = teacher
+        self.teacherEn = Self.normalizeOptional(teacherEn)
         self.teachers = teachers ?? Self.normalizeTeachers(primary: teacher, extras: [])
         self.time = time
         self.sessionNumbers = sessionNumbers
@@ -119,7 +122,8 @@ struct Course: Identifiable, Hashable, Codable {
     }
 
     enum CodingKeys: String, CodingKey {
-        case id, name, enName, cosNo, cosEleSeq, room, teacher, teachers, time, sessionNumbers
+        case id, name, enName, cosNo, cosEleSeq, room, teacher, teacherEn, teachers, time,
+            sessionNumbers
         case startTime, endTime, seatNo, stdNo, weekday, note, remark
         case startMinuteOfDay, endMinuteOfDay, durationMinutes, sortKey, sourceProvider
     }
@@ -133,6 +137,7 @@ struct Course: Identifiable, Hashable, Codable {
         cosEleSeq = try c.decodeIfPresent(String.self, forKey: .cosEleSeq)
         room = try c.decode(String.self, forKey: .room)
         teacher = try c.decode(String.self, forKey: .teacher)
+        teacherEn = Self.normalizeOptional(try c.decodeIfPresent(String.self, forKey: .teacherEn))
         let decodedTeachers = try c.decodeIfPresent([String].self, forKey: .teachers) ?? []
         teachers = Self.normalizeTeachers(primary: teacher, extras: decodedTeachers)
         time = try c.decode(String.self, forKey: .time)
@@ -179,6 +184,7 @@ struct Course: Identifiable, Hashable, Codable {
         try c.encodeIfPresent(cosEleSeq, forKey: .cosEleSeq)
         try c.encode(room, forKey: .room)
         try c.encode(teacher, forKey: .teacher)
+        try c.encodeIfPresent(teacherEn, forKey: .teacherEn)
         try c.encode(teachers, forKey: .teachers)
         try c.encode(time, forKey: .time)
         try c.encode(sessionNumbers, forKey: .sessionNumbers)
@@ -194,6 +200,45 @@ struct Course: Identifiable, Hashable, Codable {
         try c.encode(durationMinutes, forKey: .durationMinutes)
         try c.encode(sortKey, forKey: .sortKey)
         try c.encode(sourceProvider, forKey: .sourceProvider)
+    }
+}
+
+extension Course {
+    func displayName(showEnglish: Bool) -> String {
+        guard showEnglish,
+            let enName,
+            !enName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return name
+        }
+        return enName
+    }
+
+    func displayTeacher(showEnglish: Bool) -> String {
+        guard showEnglish,
+            let teacherEn,
+            !teacherEn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        else {
+            return teacher
+        }
+        return teacherEn
+    }
+
+    static func defaultShowEnglishCourseName() -> Bool {
+        shouldShowEnglishCourseName(forPreferredLanguage: Locale.preferredLanguages.first)
+    }
+
+    static func defaultShowEnglishTeacherName() -> Bool {
+        shouldShowEnglishCourseName(forPreferredLanguage: Locale.preferredLanguages.first)
+    }
+
+    static func shouldShowEnglishCourseName(forPreferredLanguage preferredLanguage: String?) -> Bool {
+        guard let preferredLanguage else { return true }
+        let normalized = preferredLanguage.lowercased().replacingOccurrences(of: "_", with: "-")
+        let isTraditionalChinese =
+            normalized.hasPrefix("zh-hant") || normalized.hasPrefix("zh-tw")
+            || normalized.hasPrefix("zh-hk") || normalized.hasPrefix("zh-mo")
+        return !isTraditionalChinese
     }
 }
 

--- a/app/dauphin/Models/Course.swift
+++ b/app/dauphin/Models/Course.swift
@@ -33,26 +33,11 @@ struct Course: Identifiable, Hashable, Codable {
     var stdNo: String { seatNo ?? "" }
 
     init(
-        id: String? = nil,
-        name: String,
-        enName: String? = nil,
-        cosNo: String? = nil,
-        cosEleSeq: String? = nil,
-        room: String,
-        teacher: String,
-        teachers: [String]? = nil,
-        time: String,
-        sessionNumbers: [Int] = [],
-        startTime: Date,
-        endTime: Date,
-        stdNo: String,
-        weekday: Int,
-        note: String = "",
-        remark: String? = nil,
-        startMinuteOfDay: Int? = nil,
-        endMinuteOfDay: Int? = nil,
-        durationMinutes: Int? = nil,
-        sortKey: Int? = nil,
+        id: String? = nil, name: String, enName: String? = nil, cosNo: String? = nil,
+        cosEleSeq: String? = nil, room: String, teacher: String, teachers: [String]? = nil,
+        time: String, sessionNumbers: [Int] = [], startTime: Date, endTime: Date, stdNo: String,
+        weekday: Int, note: String = "", remark: String? = nil, startMinuteOfDay: Int? = nil,
+        endMinuteOfDay: Int? = nil, durationMinutes: Int? = nil, sortKey: Int? = nil,
         sourceProvider: String = "stuelelist"
     ) {
         self.name = name
@@ -83,14 +68,9 @@ struct Course: Identifiable, Hashable, Codable {
         self.id =
             id
             ?? Self.makeStableID(
-                name: name,
-                weekday: weekday,
-                sessionNumbers: sessionNumbers,
-                startMinuteOfDay: computedStartMinute,
-                endMinuteOfDay: computedEndMinute,
-                room: room,
-                cosEleSeq: cosEleSeq,
-                seatNo: normalizedSeat)
+                name: name, weekday: weekday, sessionNumbers: sessionNumbers,
+                startMinuteOfDay: computedStartMinute, endMinuteOfDay: computedEndMinute,
+                room: room, cosEleSeq: cosEleSeq, seatNo: normalizedSeat)
     }
 
     private static func minuteOfDay(_ date: Date) -> Int {
@@ -118,24 +98,12 @@ struct Course: Identifiable, Hashable, Codable {
     }
 
     private static func makeStableID(
-        name: String,
-        weekday: Int,
-        sessionNumbers: [Int],
-        startMinuteOfDay: Int,
-        endMinuteOfDay: Int,
-        room: String,
-        cosEleSeq: String?,
-        seatNo: String?
+        name: String, weekday: Int, sessionNumbers: [Int], startMinuteOfDay: Int,
+        endMinuteOfDay: Int, room: String, cosEleSeq: String?, seatNo: String?
     ) -> String {
         let base = [
-            name,
-            String(weekday),
-            sessionNumbers.map(String.init).joined(separator: ","),
-            String(startMinuteOfDay),
-            String(endMinuteOfDay),
-            room,
-            cosEleSeq ?? "",
-            seatNo ?? "",
+            name, String(weekday), sessionNumbers.map(String.init).joined(separator: ","),
+            String(startMinuteOfDay), String(endMinuteOfDay), room, cosEleSeq ?? "", seatNo ?? "",
         ].joined(separator: "|")
         return "course_\(fnv1a64Hex(base))"
     }
@@ -184,24 +152,22 @@ struct Course: Identifiable, Hashable, Codable {
         let fallbackEndMinute = Self.minuteOfDay(endTime)
         startMinuteOfDay =
             try c.decodeIfPresent(Int.self, forKey: .startMinuteOfDay) ?? fallbackStartMinute
-        endMinuteOfDay = try c.decodeIfPresent(Int.self, forKey: .endMinuteOfDay) ?? fallbackEndMinute
+        endMinuteOfDay =
+            try c.decodeIfPresent(Int.self, forKey: .endMinuteOfDay) ?? fallbackEndMinute
         durationMinutes =
             try c.decodeIfPresent(Int.self, forKey: .durationMinutes)
             ?? max(0, endMinuteOfDay - startMinuteOfDay)
-        sortKey = try c.decodeIfPresent(Int.self, forKey: .sortKey) ?? (weekday * 10_000 + startMinuteOfDay)
+        sortKey =
+            try c.decodeIfPresent(Int.self, forKey: .sortKey)
+            ?? (weekday * 10_000 + startMinuteOfDay)
         sourceProvider = try c.decodeIfPresent(String.self, forKey: .sourceProvider) ?? "legacy"
 
         id =
             try c.decodeIfPresent(String.self, forKey: .id)
             ?? Self.makeStableID(
-                name: name,
-                weekday: weekday,
-                sessionNumbers: sessionNumbers,
-                startMinuteOfDay: startMinuteOfDay,
-                endMinuteOfDay: endMinuteOfDay,
-                room: room,
-                cosEleSeq: cosEleSeq,
-                seatNo: seatNo)
+                name: name, weekday: weekday, sessionNumbers: sessionNumbers,
+                startMinuteOfDay: startMinuteOfDay, endMinuteOfDay: endMinuteOfDay, room: room,
+                cosEleSeq: cosEleSeq, seatNo: seatNo)
     }
 
     func encode(to encoder: Encoder) throws {

--- a/app/dauphin/Models/Course.swift
+++ b/app/dauphin/Models/Course.swift
@@ -8,16 +8,227 @@ enum CourseLogger {
 }
 
 struct Course: Identifiable, Hashable, Codable {
-    var id = UUID()
+    var id: String
     var name: String
+    var enName: String?
+    var cosNo: String?
+    var cosEleSeq: String?
     var room: String
     var teacher: String
+    var teachers: [String]
     var time: String
+    var sessionNumbers: [Int]
     var startTime: Date
     var endTime: Date
-    var stdNo: String
+    var seatNo: String?
     var weekday: Int  // 約定：1...7 = 週一...週日
-    var note: String = ""
+    var note: String
+    var remark: String?
+    var startMinuteOfDay: Int
+    var endMinuteOfDay: Int
+    var durationMinutes: Int
+    var sortKey: Int
+    var sourceProvider: String
+
+    var stdNo: String { seatNo ?? "" }
+
+    init(
+        id: String? = nil,
+        name: String,
+        enName: String? = nil,
+        cosNo: String? = nil,
+        cosEleSeq: String? = nil,
+        room: String,
+        teacher: String,
+        teachers: [String]? = nil,
+        time: String,
+        sessionNumbers: [Int] = [],
+        startTime: Date,
+        endTime: Date,
+        stdNo: String,
+        weekday: Int,
+        note: String = "",
+        remark: String? = nil,
+        startMinuteOfDay: Int? = nil,
+        endMinuteOfDay: Int? = nil,
+        durationMinutes: Int? = nil,
+        sortKey: Int? = nil,
+        sourceProvider: String = "stuelelist"
+    ) {
+        self.name = name
+        self.enName = enName
+        self.cosNo = cosNo
+        self.cosEleSeq = cosEleSeq
+        self.room = room
+        self.teacher = teacher
+        self.teachers = teachers ?? Self.normalizeTeachers(primary: teacher, extras: [])
+        self.time = time
+        self.sessionNumbers = sessionNumbers
+        self.startTime = startTime
+        self.endTime = endTime
+        let normalizedSeat = Self.normalizeOptional(stdNo)
+        self.seatNo = normalizedSeat
+        self.weekday = weekday
+        self.note = note
+        self.remark = remark
+
+        let computedStartMinute = startMinuteOfDay ?? Self.minuteOfDay(startTime)
+        let computedEndMinute = endMinuteOfDay ?? Self.minuteOfDay(endTime)
+        self.startMinuteOfDay = computedStartMinute
+        self.endMinuteOfDay = computedEndMinute
+        self.durationMinutes = durationMinutes ?? max(0, computedEndMinute - computedStartMinute)
+        self.sortKey = sortKey ?? (weekday * 10_000 + computedStartMinute)
+        self.sourceProvider = sourceProvider
+
+        self.id =
+            id
+            ?? Self.makeStableID(
+                name: name,
+                weekday: weekday,
+                sessionNumbers: sessionNumbers,
+                startMinuteOfDay: computedStartMinute,
+                endMinuteOfDay: computedEndMinute,
+                room: room,
+                cosEleSeq: cosEleSeq,
+                seatNo: normalizedSeat)
+    }
+
+    private static func minuteOfDay(_ date: Date) -> Int {
+        let cal = Calendar.current
+        return cal.component(.hour, from: date) * 60 + cal.component(.minute, from: date)
+    }
+
+    private static func normalizeOptional(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func normalizeTeachers(primary: String, extras: [String]) -> [String] {
+        var seen = Set<String>()
+        var output: [String] = []
+        let all = [primary] + extras
+        for raw in all {
+            let t = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !t.isEmpty, seen.insert(t).inserted else { continue }
+            output.append(t)
+        }
+        if output.isEmpty { return [""] }
+        return output
+    }
+
+    private static func makeStableID(
+        name: String,
+        weekday: Int,
+        sessionNumbers: [Int],
+        startMinuteOfDay: Int,
+        endMinuteOfDay: Int,
+        room: String,
+        cosEleSeq: String?,
+        seatNo: String?
+    ) -> String {
+        let base = [
+            name,
+            String(weekday),
+            sessionNumbers.map(String.init).joined(separator: ","),
+            String(startMinuteOfDay),
+            String(endMinuteOfDay),
+            room,
+            cosEleSeq ?? "",
+            seatNo ?? "",
+        ].joined(separator: "|")
+        return "course_\(fnv1a64Hex(base))"
+    }
+
+    private static func fnv1a64Hex(_ input: String) -> String {
+        let prime: UInt64 = 1_099_511_628_211
+        var hash: UInt64 = 14_695_981_039_346_656_037
+        for b in input.utf8 {
+            hash ^= UInt64(b)
+            hash = hash &* prime
+        }
+        return String(hash, radix: 16, uppercase: false)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, enName, cosNo, cosEleSeq, room, teacher, teachers, time, sessionNumbers
+        case startTime, endTime, seatNo, stdNo, weekday, note, remark
+        case startMinuteOfDay, endMinuteOfDay, durationMinutes, sortKey, sourceProvider
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+
+        name = try c.decode(String.self, forKey: .name)
+        enName = try c.decodeIfPresent(String.self, forKey: .enName)
+        cosNo = try c.decodeIfPresent(String.self, forKey: .cosNo)
+        cosEleSeq = try c.decodeIfPresent(String.self, forKey: .cosEleSeq)
+        room = try c.decode(String.self, forKey: .room)
+        teacher = try c.decode(String.self, forKey: .teacher)
+        let decodedTeachers = try c.decodeIfPresent([String].self, forKey: .teachers) ?? []
+        teachers = Self.normalizeTeachers(primary: teacher, extras: decodedTeachers)
+        time = try c.decode(String.self, forKey: .time)
+        sessionNumbers = try c.decodeIfPresent([Int].self, forKey: .sessionNumbers) ?? []
+        startTime = try c.decode(Date.self, forKey: .startTime)
+        endTime = try c.decode(Date.self, forKey: .endTime)
+
+        let oldStdNo = try c.decodeIfPresent(String.self, forKey: .stdNo)
+        let newSeatNo = try c.decodeIfPresent(String.self, forKey: .seatNo)
+        seatNo = Self.normalizeOptional(newSeatNo ?? oldStdNo)
+
+        weekday = try c.decode(Int.self, forKey: .weekday)
+        note = try c.decodeIfPresent(String.self, forKey: .note) ?? ""
+        remark = try c.decodeIfPresent(String.self, forKey: .remark)
+
+        let fallbackStartMinute = Self.minuteOfDay(startTime)
+        let fallbackEndMinute = Self.minuteOfDay(endTime)
+        startMinuteOfDay =
+            try c.decodeIfPresent(Int.self, forKey: .startMinuteOfDay) ?? fallbackStartMinute
+        endMinuteOfDay = try c.decodeIfPresent(Int.self, forKey: .endMinuteOfDay) ?? fallbackEndMinute
+        durationMinutes =
+            try c.decodeIfPresent(Int.self, forKey: .durationMinutes)
+            ?? max(0, endMinuteOfDay - startMinuteOfDay)
+        sortKey = try c.decodeIfPresent(Int.self, forKey: .sortKey) ?? (weekday * 10_000 + startMinuteOfDay)
+        sourceProvider = try c.decodeIfPresent(String.self, forKey: .sourceProvider) ?? "legacy"
+
+        id =
+            try c.decodeIfPresent(String.self, forKey: .id)
+            ?? Self.makeStableID(
+                name: name,
+                weekday: weekday,
+                sessionNumbers: sessionNumbers,
+                startMinuteOfDay: startMinuteOfDay,
+                endMinuteOfDay: endMinuteOfDay,
+                room: room,
+                cosEleSeq: cosEleSeq,
+                seatNo: seatNo)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(name, forKey: .name)
+        try c.encodeIfPresent(enName, forKey: .enName)
+        try c.encodeIfPresent(cosNo, forKey: .cosNo)
+        try c.encodeIfPresent(cosEleSeq, forKey: .cosEleSeq)
+        try c.encode(room, forKey: .room)
+        try c.encode(teacher, forKey: .teacher)
+        try c.encode(teachers, forKey: .teachers)
+        try c.encode(time, forKey: .time)
+        try c.encode(sessionNumbers, forKey: .sessionNumbers)
+        try c.encode(startTime, forKey: .startTime)
+        try c.encode(endTime, forKey: .endTime)
+        try c.encodeIfPresent(seatNo, forKey: .seatNo)
+        try c.encode(seatNo ?? "", forKey: .stdNo)
+        try c.encode(weekday, forKey: .weekday)
+        try c.encode(note, forKey: .note)
+        try c.encodeIfPresent(remark, forKey: .remark)
+        try c.encode(startMinuteOfDay, forKey: .startMinuteOfDay)
+        try c.encode(endMinuteOfDay, forKey: .endMinuteOfDay)
+        try c.encode(durationMinutes, forKey: .durationMinutes)
+        try c.encode(sortKey, forKey: .sortKey)
+        try c.encode(sourceProvider, forKey: .sourceProvider)
+    }
 }
 
 // 共用 HH:mm formatter，避免多次建立

--- a/app/dauphin/Models/Course.swift
+++ b/app/dauphin/Models/Course.swift
@@ -36,11 +36,10 @@ struct Course: Identifiable, Hashable, Codable {
     init(
         id: String? = nil, name: String, enName: String? = nil, cosNo: String? = nil,
         cosEleSeq: String? = nil, room: String, teacher: String, teacherEn: String? = nil,
-        teachers: [String]? = nil,
-        time: String, sessionNumbers: [Int] = [], startTime: Date, endTime: Date, stdNo: String,
-        weekday: Int, note: String = "", remark: String? = nil, startMinuteOfDay: Int? = nil,
-        endMinuteOfDay: Int? = nil, durationMinutes: Int? = nil, sortKey: Int? = nil,
-        sourceProvider: String = "stuelelist"
+        teachers: [String]? = nil, time: String, sessionNumbers: [Int] = [], startTime: Date,
+        endTime: Date, stdNo: String, weekday: Int, note: String = "", remark: String? = nil,
+        startMinuteOfDay: Int? = nil, endMinuteOfDay: Int? = nil, durationMinutes: Int? = nil,
+        sortKey: Int? = nil, sourceProvider: String = "stuelelist"
     ) {
         self.name = name
         self.enName = enName
@@ -204,23 +203,22 @@ struct Course: Identifiable, Hashable, Codable {
 }
 
 extension Course {
-    func displayName(showEnglish: Bool) -> String {
-        guard showEnglish,
-            let enName,
+    func isShowingEnglishName(showEnglish: Bool) -> Bool {
+        guard showEnglish, let enName,
             !enName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
-            return name
-        }
-        return enName
+        else { return false }
+        return true
+    }
+
+    func displayName(showEnglish: Bool) -> String {
+        if isShowingEnglishName(showEnglish: showEnglish) { return enName ?? name }
+        return name
     }
 
     func displayTeacher(showEnglish: Bool) -> String {
-        guard showEnglish,
-            let teacherEn,
+        guard showEnglish, let teacherEn,
             !teacherEn.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        else {
-            return teacher
-        }
+        else { return teacher }
         return teacherEn
     }
 
@@ -232,7 +230,8 @@ extension Course {
         shouldShowEnglishCourseName(forPreferredLanguage: Locale.preferredLanguages.first)
     }
 
-    static func shouldShowEnglishCourseName(forPreferredLanguage preferredLanguage: String?) -> Bool {
+    static func shouldShowEnglishCourseName(forPreferredLanguage preferredLanguage: String?) -> Bool
+    {
         guard let preferredLanguage else { return true }
         let normalized = preferredLanguage.lowercased().replacingOccurrences(of: "_", with: "-")
         let isTraditionalChinese =

--- a/app/dauphin/Utilities/Constants.swift
+++ b/app/dauphin/Utilities/Constants.swift
@@ -15,6 +15,8 @@ enum Constants {
     static let isLoggedInKey = "isLoggedIn"
     static let loginSuccessNotification = "LoginSuccess"
     static let courses = "Courses"
+    static let showEnglishCourseName = "showEnglishCourseName"
+    static let showEnglishTeacherName = "showEnglishTeacherName"
 
     static let keychainAESKey = "AES256KEY"
     static let keychainAESIV = "AES256IV"

--- a/app/dauphin/Utilities/Courses/CourseCache.swift
+++ b/app/dauphin/Utilities/Courses/CourseCache.swift
@@ -1,8 +1,6 @@
 import Foundation
 
-private enum CourseCacheVersion {
-    static let v2 = 2
-}
+private enum CourseCacheVersion { static let v2 = 2 }
 
 struct CourseCachePayloadV2: Codable {
     let version: Int
@@ -34,16 +32,11 @@ func decodeCoursesFromCacheData(_ data: Data) -> [Course]? {
 
 private func makeCachePayloadV2(courses: [Course]) -> CourseCachePayloadV2 {
     CourseCachePayloadV2(
-        version: CourseCacheVersion.v2,
-        generatedAt: Date(),
-        courses: courses,
+        version: CourseCacheVersion.v2, generatedAt: Date(), courses: courses,
         meetingsFlat: courses.map {
             CourseMeetingDigest(
-                courseId: $0.id,
-                weekday: $0.weekday,
-                startMinuteOfDay: $0.startMinuteOfDay,
-                endMinuteOfDay: $0.endMinuteOfDay,
-                sortKey: $0.sortKey)
+                courseId: $0.id, weekday: $0.weekday, startMinuteOfDay: $0.startMinuteOfDay,
+                endMinuteOfDay: $0.endMinuteOfDay, sortKey: $0.sortKey)
         })
 }
 

--- a/app/dauphin/Utilities/Courses/CourseCache.swift
+++ b/app/dauphin/Utilities/Courses/CourseCache.swift
@@ -1,5 +1,52 @@
 import Foundation
 
+private enum CourseCacheVersion {
+    static let v2 = 2
+}
+
+struct CourseCachePayloadV2: Codable {
+    let version: Int
+    let generatedAt: Date
+    let courses: [Course]
+    let meetingsFlat: [CourseMeetingDigest]
+}
+
+struct CourseMeetingDigest: Codable, Hashable {
+    let courseId: String
+    let weekday: Int
+    let startMinuteOfDay: Int
+    let endMinuteOfDay: Int
+    let sortKey: Int
+}
+
+func decodeCoursesFromCacheData(_ data: Data) -> [Course]? {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    if let payload = try? decoder.decode(CourseCachePayloadV2.self, from: data),
+        payload.version == CourseCacheVersion.v2
+    {
+        return payload.courses
+    }
+
+    return try? decoder.decode([Course].self, from: data)
+}
+
+private func makeCachePayloadV2(courses: [Course]) -> CourseCachePayloadV2 {
+    CourseCachePayloadV2(
+        version: CourseCacheVersion.v2,
+        generatedAt: Date(),
+        courses: courses,
+        meetingsFlat: courses.map {
+            CourseMeetingDigest(
+                courseId: $0.id,
+                weekday: $0.weekday,
+                startMinuteOfDay: $0.startMinuteOfDay,
+                endMinuteOfDay: $0.endMinuteOfDay,
+                sortKey: $0.sortKey)
+        })
+}
+
 protocol CourseCache {
     func load() -> [Course]?
     func save(_ courses: [Course])
@@ -17,15 +64,14 @@ struct DefaultsCourseCache: CourseCache {
 
     func load() -> [Course]? {
         guard let data = defaults.data(forKey: key) else { return nil }
-        let dec = JSONDecoder()
-        dec.dateDecodingStrategy = .iso8601
-        return try? dec.decode([Course].self, from: data)
+        return decodeCoursesFromCacheData(data)
     }
 
     func save(_ courses: [Course]) {
         let enc = JSONEncoder()
         enc.dateEncodingStrategy = .iso8601
-        if let data = try? enc.encode(courses) { defaults.set(data, forKey: key) }
+        let payload = makeCachePayloadV2(courses: courses)
+        if let data = try? enc.encode(payload) { defaults.set(data, forKey: key) }
     }
 
     func clear() { defaults.removeObject(forKey: key) }

--- a/app/dauphin/Utilities/Courses/CourseParser.swift
+++ b/app/dauphin/Utilities/Courses/CourseParser.swift
@@ -1,24 +1,66 @@
 import Foundation
 
-private struct APIResponse: Decodable { let stuelelist: [CourseDTO] }
+private struct APIResponse: Decodable {
+    let stuelelist: [CourseDTO]?
+    let cells: [CellDTO]?
+}
 
 private struct CourseDTO: Decodable {
     let week: String
     let chCosName: String?
+    let enCosName: String?
     let note: String?
+    let remark: String?
     let room: String?
+    let cosNo: String?
+    let cosEleSeq: String?
+    let teachNameEn: String?
     let teachName: String?
     let seatNo: String?
     let timePlace: TimePlace?
+    let timePlaseText: String?
+    let sess1: String?
+    let sess2: String?
+    let sess3: String?
+
     enum CodingKeys: String, CodingKey {
         case week
         case chCosName = "ch_cos_name"
-        case note, room
+        case enCosName = "en_cos_name"
+        case note, room, remark
+        case cosNo = "cos_no"
+        case cosEleSeq = "cos_ele_seq"
         case teachName = "teach_name"
+        case teachNameEn = "teach_name_en"
         case seatNo = "seat_no"
         case timePlace = "timePlase"
+        case timePlaseText = "time_plase"
+        case sess1, sess2, sess3
     }
     struct TimePlace: Decodable { let sesses: [String] }
+}
+
+private struct CellDTO: Decodable {
+    let weekNo: String?
+    let sessNo: String?
+    let chCosName: String?
+    let enCosName: String?
+    let teachName: String?
+    let teachNameEn: String?
+    let seatNo: String?
+    let note: String?
+    let room: String?
+
+    enum CodingKeys: String, CodingKey {
+        case weekNo = "weekno"
+        case sessNo = "sessno"
+        case chCosName = "ch_cos_name"
+        case enCosName = "en_cos_name"
+        case teachName = "teach_name"
+        case teachNameEn = "teach_name_en"
+        case seatNo = "seatno"
+        case note, room
+    }
 }
 
 protocol CourseParser { func parse(_ data: Data) throws -> [Course] }
@@ -30,69 +72,199 @@ struct DefaultCourseParser: CourseParser {
 
     func parse(_ data: Data) throws -> [Course] {
         let api = try JSONDecoder().decode(APIResponse.self, from: data)
-        var items: [Course] = []
 
-        for c in api.stuelelist {
-            guard let week = Int(c.week), (1 ... 7).contains(week), let sesses = c.timePlace?.sesses
-            else { continue }
-
-            let sessionNumbers = sesses.compactMap(Int.init).sorted()
-
-            guard let firstSession = sessionNumbers.first, let lastSession = sessionNumbers.last,
-                let start = sessionToStart(firstSession), let end = sessionToEnd(lastSession)
-            else { continue }
-
-            // 所有 unknown → ""
-            let raw = htmlStrip(c.chCosName ?? "").replacingOccurrences(of: "\n", with: "")
-                .replacingOccurrences(of: "\r", with: "")
-            let name = raw.split(separator: ",", maxSplits: 1).first.map(String.init) ?? raw
-
-            let roomRaw = htmlStrip(c.room ?? "")
-            let room = roomRaw.split(separator: ",", maxSplits: 1).first.map(String.init) ?? roomRaw
-
-            let teacherRaw = htmlStrip(c.teachName ?? "")
-            let teacher =
-                teacherRaw.split(separator: ",", maxSplits: 1).first.map(String.init) ?? teacherRaw
-
-            let seatRaw = htmlStrip(c.seatNo ?? "")
-            let seatNo =
-                seatRaw.split(separator: ",", maxSplits: 1).first.map(String.init) ?? seatRaw
-
-            let time = sessionNumbers.map(String.init).joined(separator: ", ")
-            let finalRoom = room.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "" : room
-            let note = htmlStrip(c.note ?? "")
-
-            items.append(
-                Course(
-                    name: name, room: finalRoom, teacher: teacher, time: time, startTime: start,
-                    endTime: end, stdNo: seatNo, weekday: week, note: note))
+        var stueItems: [Course] = []
+        for row in api.stuelelist ?? [] {
+            guard let course = makeCourse(from: row) else { continue }
+            stueItems.append(course)
         }
 
-        return dedupeAndMerge(items)
+        if !stueItems.isEmpty {
+            return dedupeAndMerge(stueItems)
+        }
+
+        var cellItems: [Course] = []
+        for row in api.cells ?? [] {
+            guard let course = makeCourse(from: row) else { continue }
+            cellItems.append(course)
+        }
+        return dedupeAndMerge(cellItems)
+    }
+
+    private func makeCourse(from row: CourseDTO) -> Course? {
+        guard let week = Int(row.week), (1 ... 7).contains(week) else { return nil }
+        let sessions = parseSessionNumbers(from: row)
+        guard let firstSession = sessions.first, let lastSession = sessions.last,
+            let start = sessionToStart(firstSession), let end = sessionToEnd(lastSession)
+        else { return nil }
+
+        let name = cleanCourseName(row.chCosName)
+        guard !name.isEmpty else { return nil }
+
+        let enName = cleanOptional(row.enCosName)
+        let room = cleanPrimaryToken(row.room) ?? ""
+        let teacher = cleanPrimaryToken(row.teachName) ?? ""
+        let teachNameEn = cleanOptional(row.teachNameEn)
+        let seatNo = cleanPrimaryToken(row.seatNo)
+        let note = cleanOptional(row.note) ?? ""
+        let remark = cleanOptional(row.remark)
+        let cosNo = cleanOptional(row.cosNo)
+        let cosEleSeq = cleanOptional(row.cosEleSeq)
+
+        let startMinute = minuteOfDay(from: start)
+        let endMinute = minuteOfDay(from: end)
+
+        return Course(
+            name: name,
+            enName: enName,
+            cosNo: cosNo,
+            cosEleSeq: cosEleSeq,
+            room: room,
+            teacher: teacher,
+            teachers: [teacher],
+            time: sessions.map(String.init).joined(separator: ", "),
+            sessionNumbers: sessions,
+            startTime: start,
+            endTime: end,
+            stdNo: seatNo ?? "",
+            weekday: week,
+            note: note,
+            remark: [remark, teachNameEn].compactMap { $0 }.joined(separator: " | "),
+            startMinuteOfDay: startMinute,
+            endMinuteOfDay: endMinute,
+            durationMinutes: max(0, endMinute - startMinute),
+            sortKey: week * 10_000 + startMinute,
+            sourceProvider: "stuelelist")
+    }
+
+    private func makeCourse(from row: CellDTO) -> Course? {
+        guard let weekRaw = row.weekNo, let week = Int(weekRaw), (1 ... 7).contains(week) else {
+            return nil
+        }
+        guard let sessRaw = row.sessNo, let sess = Int(sessRaw) else { return nil }
+
+        let name = cleanCourseName(row.chCosName)
+        guard !name.isEmpty else { return nil }
+
+        guard let start = sessionToStart(sess), let end = sessionToEnd(sess) else { return nil }
+
+        let enName = cleanOptional(row.enCosName)
+        let room = cleanPrimaryToken(row.room) ?? ""
+        let teacher = cleanPrimaryToken(row.teachName) ?? ""
+        let teachNameEn = cleanOptional(row.teachNameEn)
+        let seatNo = cleanPrimaryToken(row.seatNo)
+        let note = cleanOptional(row.note) ?? ""
+
+        let startMinute = minuteOfDay(from: start)
+        let endMinute = minuteOfDay(from: end)
+
+        return Course(
+            name: name,
+            enName: enName,
+            room: room,
+            teacher: teacher,
+            teachers: [teacher],
+            time: String(sess),
+            sessionNumbers: [sess],
+            startTime: start,
+            endTime: end,
+            stdNo: seatNo ?? "",
+            weekday: week,
+            note: note,
+            remark: teachNameEn,
+            startMinuteOfDay: startMinute,
+            endMinuteOfDay: endMinute,
+            durationMinutes: max(0, endMinute - startMinute),
+            sortKey: week * 10_000 + startMinute,
+            sourceProvider: "cells")
+    }
+
+    private func parseSessionNumbers(from row: CourseDTO) -> [Int] {
+        let primary = row.timePlace?.sesses ?? []
+        let parsedPrimary = normalizeSessions(primary)
+        if !parsedPrimary.isEmpty { return parsedPrimary }
+
+        let fromSessFields = normalizeSessions([row.sess1, row.sess2, row.sess3].compactMap { $0 })
+        if !fromSessFields.isEmpty { return fromSessFields }
+
+        return normalizeSessions(parseSessionsFromTimePlaseText(row.timePlaseText ?? ""))
+    }
+
+    private func parseSessionsFromTimePlaseText(_ text: String) -> [String] {
+        // 格式例：一/06,07,08/E  414
+        let comps = text.split(separator: "/", omittingEmptySubsequences: false)
+        guard comps.count >= 2 else { return [] }
+        return comps[1].split(separator: ",").map(String.init)
+    }
+
+    private func normalizeSessions(_ values: [String]) -> [Int] {
+        let numbers = values.compactMap { raw -> Int? in
+            let t = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !t.isEmpty else { return nil }
+            return Int(t)
+        }
+        return Array(Set(numbers)).sorted()
+    }
+
+    private func cleanCourseName(_ raw: String?) -> String {
+        cleanOptional(raw) ?? ""
+    }
+
+    private func cleanPrimaryToken(_ raw: String?) -> String? {
+        guard let cleaned = cleanOptional(raw) else { return nil }
+        return cleaned.split(separator: ",", maxSplits: 1).first.map(String.init)
+    }
+
+    private func cleanOptional(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let noHtml = htmlStrip(raw)
+            .replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+        let trimmed = noHtml.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+        return trimmed
+    }
+
+    private func minuteOfDay(from date: Date) -> Int {
+        let cal = Calendar.current
+        return cal.component(.hour, from: date) * 60 + cal.component(.minute, from: date)
     }
 
     private func dedupeAndMerge(_ input: [Course]) -> [Course] {
         struct CourseKey: Hashable {
             let name: String
+            let enName: String?
+            let cosNo: String?
+            let cosEleSeq: String?
             let room: String
             let teacher: String
             let time: String
+            let sessionNumbers: [Int]
             let startTime: Date
             let endTime: Date
-            let stdNo: String
+            let seatNo: String?
             let weekday: Int
             let note: String
+            let remark: String?
+            let sourceProvider: String
 
             init(course: Course) {
                 self.name = course.name
+                self.enName = course.enName
+                self.cosNo = course.cosNo
+                self.cosEleSeq = course.cosEleSeq
                 self.room = course.room
                 self.teacher = course.teacher
                 self.time = course.time
+                self.sessionNumbers = course.sessionNumbers
                 self.startTime = course.startTime
                 self.endTime = course.endTime
-                self.stdNo = course.stdNo
+                self.seatNo = course.seatNo
                 self.weekday = course.weekday
                 self.note = course.note
+                self.remark = course.remark
+                self.sourceProvider = course.sourceProvider
             }
         }
 
@@ -100,25 +272,172 @@ struct DefaultCourseParser: CourseParser {
         var unique: [Course] = []
         for c in input where seen.insert(CourseKey(course: c)).inserted { unique.append(c) }
 
-        var merged: [Course] = []
+        struct MergeKey: Hashable {
+            let name: String
+            let enName: String?
+            let cosNo: String?
+            let cosEleSeq: String?
+            let room: String
+            let time: String
+            let sessionNumbers: [Int]
+            let startTime: Date
+            let endTime: Date
+            let seatNo: String?
+            let weekday: Int
+            let note: String
+            let remark: String?
+            let sourceProvider: String
+        }
+
+        var mergedByKey: [MergeKey: Course] = [:]
         for course in unique {
-            if let idx = merged.firstIndex(where: { e in
-                e.name == course.name && e.room == course.room && e.time == course.time
-                    && e.stdNo == course.stdNo && e.weekday == course.weekday
-                    && e.startTime == course.startTime && e.endTime == course.endTime
-                    && e.note == course.note
-            }) {
-                var m = merged[idx]
-                var t = Set(
-                    m.teacher.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) })
-                t.insert(course.teacher)
-                m.teacher = t.sorted().joined(separator: ", ")
-                merged[idx] = m
+            let key = MergeKey(
+                name: course.name,
+                enName: course.enName,
+                cosNo: course.cosNo,
+                cosEleSeq: course.cosEleSeq,
+                room: course.room,
+                time: course.time,
+                sessionNumbers: course.sessionNumbers,
+                startTime: course.startTime,
+                endTime: course.endTime,
+                seatNo: course.seatNo,
+                weekday: course.weekday,
+                note: course.note,
+                remark: course.remark,
+                sourceProvider: course.sourceProvider)
+
+            if var existing = mergedByKey[key] {
+                var set = Set(existing.teachers)
+                for t in course.teachers where !t.isEmpty { set.insert(t) }
+                if !course.teacher.isEmpty { set.insert(course.teacher) }
+                let ordered = set.sorted()
+                existing.teachers = ordered
+                existing.teacher = ordered.joined(separator: ", ")
+                mergedByKey[key] = existing
             } else {
-                merged.append(course)
+                var normalized = course
+                let teacherSet = Set((course.teachers + [course.teacher]).filter { !$0.isEmpty })
+                let ordered = teacherSet.sorted()
+                normalized.teachers = ordered
+                normalized.teacher = ordered.joined(separator: ", ")
+                mergedByKey[key] = normalized
             }
         }
-        CourseLogger.logger.info("Successfully parsed \(merged.count) courses")
-        return merged
+        let merged = mergedByKey.values.sorted { lhs, rhs in
+            if lhs.weekday != rhs.weekday { return lhs.weekday < rhs.weekday }
+            if lhs.startMinuteOfDay != rhs.startMinuteOfDay {
+                return lhs.startMinuteOfDay < rhs.startMinuteOfDay
+            }
+            return lhs.name < rhs.name
+        }
+        let compressed = mergeAdjacentMeetings(merged)
+        CourseLogger.logger.info("Successfully parsed \(compressed.count) courses")
+        return compressed
+    }
+
+    private func mergeAdjacentMeetings(_ courses: [Course]) -> [Course] {
+        struct MergeLineKey: Hashable {
+            let name: String
+            let enName: String?
+            let cosNo: String?
+            let cosEleSeq: String?
+            let room: String
+            let teacher: String
+            let teachers: [String]
+            let seatNo: String?
+            let weekday: Int
+            let note: String
+            let remark: String?
+            let sourceProvider: String
+        }
+
+        let grouped = Dictionary(grouping: courses) {
+            MergeLineKey(
+                name: $0.name,
+                enName: $0.enName,
+                cosNo: $0.cosNo,
+                cosEleSeq: $0.cosEleSeq,
+                room: $0.room,
+                teacher: $0.teacher,
+                teachers: $0.teachers,
+                seatNo: $0.seatNo,
+                weekday: $0.weekday,
+                note: $0.note,
+                remark: $0.remark,
+                sourceProvider: $0.sourceProvider)
+        }
+
+        var output: [Course] = []
+        for (_, group) in grouped {
+            let sorted = group.sorted {
+                if $0.weekday != $1.weekday { return $0.weekday < $1.weekday }
+                return $0.startMinuteOfDay < $1.startMinuteOfDay
+            }
+
+            var accumulator: Course?
+            for course in sorted {
+                guard var current = accumulator else {
+                    accumulator = course
+                    continue
+                }
+
+                if canMergeContiguous(current, course) {
+                    current = buildMergedCourse(lhs: current, rhs: course)
+                    accumulator = current
+                } else {
+                    output.append(current)
+                    accumulator = course
+                }
+            }
+            if let accumulator { output.append(accumulator) }
+        }
+
+        return output.sorted {
+            if $0.weekday != $1.weekday { return $0.weekday < $1.weekday }
+            if $0.startMinuteOfDay != $1.startMinuteOfDay {
+                return $0.startMinuteOfDay < $1.startMinuteOfDay
+            }
+            return $0.name < $1.name
+        }
+    }
+
+    private func canMergeContiguous(_ lhs: Course, _ rhs: Course) -> Bool {
+        guard lhs.weekday == rhs.weekday else { return false }
+        guard let lhsMax = lhs.sessionNumbers.max(), let rhsMin = rhs.sessionNumbers.min() else {
+            return false
+        }
+        return lhsMax + 1 == rhsMin
+    }
+
+    private func buildMergedCourse(lhs: Course, rhs: Course) -> Course {
+        let sessions = Array(Set(lhs.sessionNumbers + rhs.sessionNumbers)).sorted()
+        let start = lhs.startMinuteOfDay <= rhs.startMinuteOfDay ? lhs : rhs
+        let end = lhs.endMinuteOfDay >= rhs.endMinuteOfDay ? lhs : rhs
+        let teachers = Array(Set(lhs.teachers + rhs.teachers + [lhs.teacher, rhs.teacher]))
+            .filter { !$0.isEmpty }
+            .sorted()
+
+        return Course(
+            name: lhs.name,
+            enName: lhs.enName,
+            cosNo: lhs.cosNo,
+            cosEleSeq: lhs.cosEleSeq,
+            room: lhs.room,
+            teacher: teachers.joined(separator: ", "),
+            teachers: teachers,
+            time: sessions.map(String.init).joined(separator: ", "),
+            sessionNumbers: sessions,
+            startTime: start.startTime,
+            endTime: end.endTime,
+            stdNo: lhs.seatNo ?? "",
+            weekday: lhs.weekday,
+            note: lhs.note,
+            remark: lhs.remark,
+            startMinuteOfDay: start.startMinuteOfDay,
+            endMinuteOfDay: end.endMinuteOfDay,
+            durationMinutes: max(0, end.endMinuteOfDay - start.startMinuteOfDay),
+            sortKey: lhs.weekday * 10_000 + start.startMinuteOfDay,
+            sourceProvider: lhs.sourceProvider)
     }
 }

--- a/app/dauphin/Utilities/Courses/CourseParser.swift
+++ b/app/dauphin/Utilities/Courses/CourseParser.swift
@@ -114,10 +114,10 @@ struct DefaultCourseParser: CourseParser {
 
         return Course(
             name: name, enName: enName, cosNo: cosNo, cosEleSeq: cosEleSeq, room: room,
-            teacher: teacher, teachers: [teacher],
+            teacher: teacher, teacherEn: teachNameEn, teachers: [teacher],
             time: sessions.map(String.init).joined(separator: ", "), sessionNumbers: sessions,
             startTime: start, endTime: end, stdNo: seatNo ?? "", weekday: week, note: note,
-            remark: [remark, teachNameEn].compactMap { $0 }.joined(separator: " | "),
+            remark: remark,
             startMinuteOfDay: startMinute, endMinuteOfDay: endMinute,
             durationMinutes: max(0, endMinute - startMinute), sortKey: week * 10_000 + startMinute,
             sourceProvider: "stuelelist")
@@ -145,7 +145,8 @@ struct DefaultCourseParser: CourseParser {
         let endMinute = minuteOfDay(from: end)
 
         return Course(
-            name: name, enName: enName, room: room, teacher: teacher, teachers: [teacher],
+            name: name, enName: enName, room: room, teacher: teacher, teacherEn: teachNameEn,
+            teachers: [teacher],
             time: String(sess), sessionNumbers: [sess], startTime: start, endTime: end,
             stdNo: seatNo ?? "", weekday: week, note: note, remark: teachNameEn,
             startMinuteOfDay: startMinute, endMinuteOfDay: endMinute,
@@ -209,6 +210,7 @@ struct DefaultCourseParser: CourseParser {
             let cosEleSeq: String?
             let room: String
             let teacher: String
+            let teacherEn: String?
             let time: String
             let sessionNumbers: [Int]
             let startTime: Date
@@ -226,6 +228,7 @@ struct DefaultCourseParser: CourseParser {
                 self.cosEleSeq = course.cosEleSeq
                 self.room = course.room
                 self.teacher = course.teacher
+                self.teacherEn = course.teacherEn
                 self.time = course.time
                 self.sessionNumbers = course.sessionNumbers
                 self.startTime = course.startTime
@@ -248,6 +251,7 @@ struct DefaultCourseParser: CourseParser {
             let cosNo: String?
             let cosEleSeq: String?
             let room: String
+            let teacherEn: String?
             let time: String
             let sessionNumbers: [Int]
             let startTime: Date
@@ -263,7 +267,8 @@ struct DefaultCourseParser: CourseParser {
         for course in unique {
             let key = MergeKey(
                 name: course.name, enName: course.enName, cosNo: course.cosNo,
-                cosEleSeq: course.cosEleSeq, room: course.room, time: course.time,
+                cosEleSeq: course.cosEleSeq, room: course.room, teacherEn: course.teacherEn,
+                time: course.time,
                 sessionNumbers: course.sessionNumbers, startTime: course.startTime,
                 endTime: course.endTime, seatNo: course.seatNo, weekday: course.weekday,
                 note: course.note, remark: course.remark, sourceProvider: course.sourceProvider)
@@ -305,6 +310,7 @@ struct DefaultCourseParser: CourseParser {
             let cosEleSeq: String?
             let room: String
             let teacher: String
+            let teacherEn: String?
             let teachers: [String]
             let seatNo: String?
             let weekday: Int
@@ -316,7 +322,8 @@ struct DefaultCourseParser: CourseParser {
         let grouped = Dictionary(grouping: courses) {
             MergeLineKey(
                 name: $0.name, enName: $0.enName, cosNo: $0.cosNo, cosEleSeq: $0.cosEleSeq,
-                room: $0.room, teacher: $0.teacher, teachers: $0.teachers, seatNo: $0.seatNo,
+                room: $0.room, teacher: $0.teacher, teacherEn: $0.teacherEn, teachers: $0.teachers,
+                seatNo: $0.seatNo,
                 weekday: $0.weekday, note: $0.note, remark: $0.remark,
                 sourceProvider: $0.sourceProvider)
         }
@@ -373,7 +380,8 @@ struct DefaultCourseParser: CourseParser {
 
         return Course(
             name: lhs.name, enName: lhs.enName, cosNo: lhs.cosNo, cosEleSeq: lhs.cosEleSeq,
-            room: lhs.room, teacher: teachers.joined(separator: ", "), teachers: teachers,
+            room: lhs.room, teacher: teachers.joined(separator: ", "),
+            teacherEn: lhs.teacherEn ?? rhs.teacherEn, teachers: teachers,
             time: sessions.map(String.init).joined(separator: ", "), sessionNumbers: sessions,
             startTime: start.startTime, endTime: end.endTime, stdNo: lhs.seatNo ?? "",
             weekday: lhs.weekday, note: lhs.note, remark: lhs.remark,

--- a/app/dauphin/Utilities/Courses/CourseParser.swift
+++ b/app/dauphin/Utilities/Courses/CourseParser.swift
@@ -79,9 +79,7 @@ struct DefaultCourseParser: CourseParser {
             stueItems.append(course)
         }
 
-        if !stueItems.isEmpty {
-            return dedupeAndMerge(stueItems)
-        }
+        if !stueItems.isEmpty { return dedupeAndMerge(stueItems) }
 
         var cellItems: [Course] = []
         for row in api.cells ?? [] {
@@ -115,25 +113,13 @@ struct DefaultCourseParser: CourseParser {
         let endMinute = minuteOfDay(from: end)
 
         return Course(
-            name: name,
-            enName: enName,
-            cosNo: cosNo,
-            cosEleSeq: cosEleSeq,
-            room: room,
-            teacher: teacher,
-            teachers: [teacher],
-            time: sessions.map(String.init).joined(separator: ", "),
-            sessionNumbers: sessions,
-            startTime: start,
-            endTime: end,
-            stdNo: seatNo ?? "",
-            weekday: week,
-            note: note,
+            name: name, enName: enName, cosNo: cosNo, cosEleSeq: cosEleSeq, room: room,
+            teacher: teacher, teachers: [teacher],
+            time: sessions.map(String.init).joined(separator: ", "), sessionNumbers: sessions,
+            startTime: start, endTime: end, stdNo: seatNo ?? "", weekday: week, note: note,
             remark: [remark, teachNameEn].compactMap { $0 }.joined(separator: " | "),
-            startMinuteOfDay: startMinute,
-            endMinuteOfDay: endMinute,
-            durationMinutes: max(0, endMinute - startMinute),
-            sortKey: week * 10_000 + startMinute,
+            startMinuteOfDay: startMinute, endMinuteOfDay: endMinute,
+            durationMinutes: max(0, endMinute - startMinute), sortKey: week * 10_000 + startMinute,
             sourceProvider: "stuelelist")
     }
 
@@ -159,23 +145,11 @@ struct DefaultCourseParser: CourseParser {
         let endMinute = minuteOfDay(from: end)
 
         return Course(
-            name: name,
-            enName: enName,
-            room: room,
-            teacher: teacher,
-            teachers: [teacher],
-            time: String(sess),
-            sessionNumbers: [sess],
-            startTime: start,
-            endTime: end,
-            stdNo: seatNo ?? "",
-            weekday: week,
-            note: note,
-            remark: teachNameEn,
-            startMinuteOfDay: startMinute,
-            endMinuteOfDay: endMinute,
-            durationMinutes: max(0, endMinute - startMinute),
-            sortKey: week * 10_000 + startMinute,
+            name: name, enName: enName, room: room, teacher: teacher, teachers: [teacher],
+            time: String(sess), sessionNumbers: [sess], startTime: start, endTime: end,
+            stdNo: seatNo ?? "", weekday: week, note: note, remark: teachNameEn,
+            startMinuteOfDay: startMinute, endMinuteOfDay: endMinute,
+            durationMinutes: max(0, endMinute - startMinute), sortKey: week * 10_000 + startMinute,
             sourceProvider: "cells")
     }
 
@@ -206,9 +180,7 @@ struct DefaultCourseParser: CourseParser {
         return Array(Set(numbers)).sorted()
     }
 
-    private func cleanCourseName(_ raw: String?) -> String {
-        cleanOptional(raw) ?? ""
-    }
+    private func cleanCourseName(_ raw: String?) -> String { cleanOptional(raw) ?? "" }
 
     private func cleanPrimaryToken(_ raw: String?) -> String? {
         guard let cleaned = cleanOptional(raw) else { return nil }
@@ -217,10 +189,8 @@ struct DefaultCourseParser: CourseParser {
 
     private func cleanOptional(_ raw: String?) -> String? {
         guard let raw else { return nil }
-        let noHtml = htmlStrip(raw)
-            .replacingOccurrences(of: "&nbsp;", with: " ")
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\r", with: " ")
+        let noHtml = htmlStrip(raw).replacingOccurrences(of: "&nbsp;", with: " ")
+            .replacingOccurrences(of: "\n", with: " ").replacingOccurrences(of: "\r", with: " ")
         let trimmed = noHtml.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return nil }
         return trimmed
@@ -292,20 +262,11 @@ struct DefaultCourseParser: CourseParser {
         var mergedByKey: [MergeKey: Course] = [:]
         for course in unique {
             let key = MergeKey(
-                name: course.name,
-                enName: course.enName,
-                cosNo: course.cosNo,
-                cosEleSeq: course.cosEleSeq,
-                room: course.room,
-                time: course.time,
-                sessionNumbers: course.sessionNumbers,
-                startTime: course.startTime,
-                endTime: course.endTime,
-                seatNo: course.seatNo,
-                weekday: course.weekday,
-                note: course.note,
-                remark: course.remark,
-                sourceProvider: course.sourceProvider)
+                name: course.name, enName: course.enName, cosNo: course.cosNo,
+                cosEleSeq: course.cosEleSeq, room: course.room, time: course.time,
+                sessionNumbers: course.sessionNumbers, startTime: course.startTime,
+                endTime: course.endTime, seatNo: course.seatNo, weekday: course.weekday,
+                note: course.note, remark: course.remark, sourceProvider: course.sourceProvider)
 
             if var existing = mergedByKey[key] {
                 var set = Set(existing.teachers)
@@ -354,17 +315,9 @@ struct DefaultCourseParser: CourseParser {
 
         let grouped = Dictionary(grouping: courses) {
             MergeLineKey(
-                name: $0.name,
-                enName: $0.enName,
-                cosNo: $0.cosNo,
-                cosEleSeq: $0.cosEleSeq,
-                room: $0.room,
-                teacher: $0.teacher,
-                teachers: $0.teachers,
-                seatNo: $0.seatNo,
-                weekday: $0.weekday,
-                note: $0.note,
-                remark: $0.remark,
+                name: $0.name, enName: $0.enName, cosNo: $0.cosNo, cosEleSeq: $0.cosEleSeq,
+                room: $0.room, teacher: $0.teacher, teachers: $0.teachers, seatNo: $0.seatNo,
+                weekday: $0.weekday, note: $0.note, remark: $0.remark,
                 sourceProvider: $0.sourceProvider)
         }
 
@@ -414,28 +367,17 @@ struct DefaultCourseParser: CourseParser {
         let sessions = Array(Set(lhs.sessionNumbers + rhs.sessionNumbers)).sorted()
         let start = lhs.startMinuteOfDay <= rhs.startMinuteOfDay ? lhs : rhs
         let end = lhs.endMinuteOfDay >= rhs.endMinuteOfDay ? lhs : rhs
-        let teachers = Array(Set(lhs.teachers + rhs.teachers + [lhs.teacher, rhs.teacher]))
-            .filter { !$0.isEmpty }
-            .sorted()
+        let teachers = Array(Set(lhs.teachers + rhs.teachers + [lhs.teacher, rhs.teacher])).filter {
+            !$0.isEmpty
+        }.sorted()
 
         return Course(
-            name: lhs.name,
-            enName: lhs.enName,
-            cosNo: lhs.cosNo,
-            cosEleSeq: lhs.cosEleSeq,
-            room: lhs.room,
-            teacher: teachers.joined(separator: ", "),
-            teachers: teachers,
-            time: sessions.map(String.init).joined(separator: ", "),
-            sessionNumbers: sessions,
-            startTime: start.startTime,
-            endTime: end.endTime,
-            stdNo: lhs.seatNo ?? "",
-            weekday: lhs.weekday,
-            note: lhs.note,
-            remark: lhs.remark,
-            startMinuteOfDay: start.startMinuteOfDay,
-            endMinuteOfDay: end.endMinuteOfDay,
+            name: lhs.name, enName: lhs.enName, cosNo: lhs.cosNo, cosEleSeq: lhs.cosEleSeq,
+            room: lhs.room, teacher: teachers.joined(separator: ", "), teachers: teachers,
+            time: sessions.map(String.init).joined(separator: ", "), sessionNumbers: sessions,
+            startTime: start.startTime, endTime: end.endTime, stdNo: lhs.seatNo ?? "",
+            weekday: lhs.weekday, note: lhs.note, remark: lhs.remark,
+            startMinuteOfDay: start.startMinuteOfDay, endMinuteOfDay: end.endMinuteOfDay,
             durationMinutes: max(0, end.endMinuteOfDay - start.startMinuteOfDay),
             sortKey: lhs.weekday * 10_000 + start.startMinuteOfDay,
             sourceProvider: lhs.sourceProvider)

--- a/app/dauphin/Utilities/Courses/CourseParser.swift
+++ b/app/dauphin/Utilities/Courses/CourseParser.swift
@@ -148,7 +148,7 @@ struct DefaultCourseParser: CourseParser {
             name: name, enName: enName, room: room, teacher: teacher, teacherEn: teachNameEn,
             teachers: [teacher],
             time: String(sess), sessionNumbers: [sess], startTime: start, endTime: end,
-            stdNo: seatNo ?? "", weekday: week, note: note, remark: teachNameEn,
+            stdNo: seatNo ?? "", weekday: week, note: note, remark: nil,
             startMinuteOfDay: startMinute, endMinuteOfDay: endMinute,
             durationMinutes: max(0, endMinute - startMinute), sortKey: week * 10_000 + startMinute,
             sourceProvider: "cells")

--- a/app/dauphin/Utilities/Courses/NextUpService.swift
+++ b/app/dauphin/Utilities/Courses/NextUpService.swift
@@ -11,23 +11,20 @@ struct DefaultNextUpService: NextUpService {
         let sys = cal.component(.weekday, from: now)
         let today = (sys == 1) ? 7 : (sys - 1)
 
-        // 依 weekday、開始時間排序
+        // 依 weekday、開始分鐘排序
         let sorted = weekly.sorted { a, b in
             if a.weekday != b.weekday { return a.weekday < b.weekday }
-            let sh1 = cal.component(.hour, from: a.startTime)
-            let sm1 = cal.component(.minute, from: a.startTime)
-            let sh2 = cal.component(.hour, from: b.startTime)
-            let sm2 = cal.component(.minute, from: b.startTime)
-            guard let s1 = cal.date(bySettingHour: sh1, minute: sm1, second: 0, of: now),
-                let s2 = cal.date(bySettingHour: sh2, minute: sm2, second: 0, of: now)
-            else { return false }
-            return s1 < s2
+            return a.startMinuteOfDay < b.startMinuteOfDay
         }
 
         let upcoming = sorted.filter { c in
             if c.weekday < today { return false }
             if c.weekday > today { return true }
-            guard let end = alignedEndDate(for: c, calendar: cal, reference: now) else {
+            guard let end = alignedDate(
+                minuteOfDay: c.endMinuteOfDay,
+                calendar: cal,
+                reference: now)
+            else {
                 return false
             }
             return end.timeIntervalSince(now) > upcomingThreshold
@@ -43,9 +40,9 @@ struct DefaultNextUpService: NextUpService {
         return upcoming
     }
 
-    private func alignedEndDate(for course: Course, calendar: Calendar, reference: Date) -> Date? {
-        let hour = calendar.component(.hour, from: course.endTime)
-        let minute = calendar.component(.minute, from: course.endTime)
+    private func alignedDate(minuteOfDay: Int, calendar: Calendar, reference: Date) -> Date? {
+        let hour = minuteOfDay / 60
+        let minute = minuteOfDay % 60
         return calendar.date(bySettingHour: hour, minute: minute, second: 0, of: reference)
     }
 }

--- a/app/dauphin/Utilities/Courses/NextUpService.swift
+++ b/app/dauphin/Utilities/Courses/NextUpService.swift
@@ -20,13 +20,9 @@ struct DefaultNextUpService: NextUpService {
         let upcoming = sorted.filter { c in
             if c.weekday < today { return false }
             if c.weekday > today { return true }
-            guard let end = alignedDate(
-                minuteOfDay: c.endMinuteOfDay,
-                calendar: cal,
-                reference: now)
-            else {
-                return false
-            }
+            guard
+                let end = alignedDate(minuteOfDay: c.endMinuteOfDay, calendar: cal, reference: now)
+            else { return false }
             return end.timeIntervalSince(now) > upcomingThreshold
         }
 

--- a/app/dauphin/View/CourseSchedule/Day/CourseCardView.swift
+++ b/app/dauphin/View/CourseSchedule/Day/CourseCardView.swift
@@ -2,12 +2,15 @@ import SwiftUI
 
 struct CourseCardView: View {
     let courseName: String
+    let useCompactCourseNameFont: Bool
     let roomNumber: String
     let teacherName: String
     let startTime: Date
     let endTime: Date
     let stdNo: String
     let weekday: Int
+
+    private var courseNameFontSize: CGFloat { useCompactCourseNameFont ? 18 : 20 }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 5) {
@@ -21,8 +24,8 @@ struct CourseCardView: View {
             }
 
             // Course Name
-            Text(courseName).font(.system(size: 20, weight: .semibold)).foregroundColor(.primary)
-                .lineLimit(2).fixedSize(horizontal: false, vertical: true)
+            Text(courseName).font(.system(size: courseNameFontSize, weight: .semibold))
+                .foregroundColor(.primary).lineLimit(2).fixedSize(horizontal: false, vertical: true)
 
             VStack(alignment: .leading, spacing: 8) {
                 // Course Details
@@ -65,7 +68,7 @@ struct CourseCardView: View {
 
 #Preview {
     CourseCardView(
-        courseName: "計算機組織", roomNumber: "E305", teacherName: "我", startTime: stringToTime("8:10")!,
-        endTime: stringToTime("9:00")!, stdNo: "178", weekday: 1
+        courseName: "計算機組織", useCompactCourseNameFont: false, roomNumber: "E305", teacherName: "我",
+        startTime: stringToTime("8:10")!, endTime: stringToTime("9:00")!, stdNo: "178", weekday: 1
     ).padding()
 }

--- a/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
+++ b/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
@@ -7,15 +7,12 @@ struct DayScheduleView: View {
     @State private var showBarcode = false
     @State private var selectedCourse: Course? = nil
     @AppStorage(
-        Constants.showEnglishCourseName,
-        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
-    )
-    private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
+        Constants.showEnglishCourseName, store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    ) private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
     @AppStorage(
         Constants.showEnglishTeacherName,
-        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
-    )
-    private var showEnglishTeacherName = Course.defaultShowEnglishTeacherName()
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)) private
+        var showEnglishTeacherName = Course.defaultShowEnglishTeacherName()
 
     private func getFormattedDate() -> String { Date.now.formatted(Self.monthYearStyle) }
 
@@ -70,12 +67,12 @@ struct DayScheduleView: View {
                         ForEach(todaysCourses) { course in
                             CourseCardView(
                                 courseName: course.displayName(showEnglish: showEnglishCourseName),
-                                roomNumber: course.room,
+                                useCompactCourseNameFont: course.isShowingEnglishName(
+                                    showEnglish: showEnglishCourseName), roomNumber: course.room,
                                 teacherName: course.displayTeacher(
-                                    showEnglish: showEnglishTeacherName
-                                ), startTime: course.startTime,
-                                endTime: course.endTime, stdNo: course.stdNo,
-                                weekday: course.weekday
+                                    showEnglish: showEnglishTeacherName),
+                                startTime: course.startTime, endTime: course.endTime,
+                                stdNo: course.stdNo, weekday: course.weekday
                             ).shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)
                                 .scaleEffect(1.0).animation(
                                     .spring(response: 0.3, dampingFraction: 0.7), value: course.id

--- a/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
+++ b/app/dauphin/View/CourseSchedule/Day/DayScheduleView.swift
@@ -6,6 +6,16 @@ struct DayScheduleView: View {
     @State private var selectedDateIndex: Int = 0  // 0...6 (Mon...Sun)
     @State private var showBarcode = false
     @State private var selectedCourse: Course? = nil
+    @AppStorage(
+        Constants.showEnglishCourseName,
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    )
+    private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
+    @AppStorage(
+        Constants.showEnglishTeacherName,
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    )
+    private var showEnglishTeacherName = Course.defaultShowEnglishTeacherName()
 
     private func getFormattedDate() -> String { Date.now.formatted(Self.monthYearStyle) }
 
@@ -59,8 +69,11 @@ struct DayScheduleView: View {
                     LazyVStack(spacing: 12) {
                         ForEach(todaysCourses) { course in
                             CourseCardView(
-                                courseName: course.name, roomNumber: course.room,
-                                teacherName: course.teacher, startTime: course.startTime,
+                                courseName: course.displayName(showEnglish: showEnglishCourseName),
+                                roomNumber: course.room,
+                                teacherName: course.displayTeacher(
+                                    showEnglish: showEnglishTeacherName
+                                ), startTime: course.startTime,
                                 endTime: course.endTime, stdNo: course.stdNo,
                                 weekday: course.weekday
                             ).shadow(color: Color.black.opacity(0.05), radius: 4, x: 0, y: 2)

--- a/app/dauphin/View/CourseSchedule/Shared/CourseDetailView.swift
+++ b/app/dauphin/View/CourseSchedule/Shared/CourseDetailView.swift
@@ -10,6 +10,16 @@ import SwiftUI
 struct CourseDetailView: View {
     let course: Course
     @Environment(\.dismiss) var dismiss
+    @AppStorage(
+        Constants.showEnglishCourseName,
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    )
+    private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
+    @AppStorage(
+        Constants.showEnglishTeacherName,
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    )
+    private var showEnglishTeacherName = Course.defaultShowEnglishTeacherName()
 
     // Cache expensive computations
     private let dayOfWeek: String
@@ -48,7 +58,10 @@ struct CourseDetailView: View {
                     Divider()
                     detailRow(title: "Seat Number", content: course.stdNo)
                     Divider()
-                    detailRow(title: "Instructor", content: course.teacher)
+                    detailRow(
+                        title: "Instructor",
+                        content: course.displayTeacher(showEnglish: showEnglishTeacherName)
+                    )
 
                     if hasNote {
                         Divider()
@@ -63,7 +76,8 @@ struct CourseDetailView: View {
 
                 }.padding(24)
 
-            }.navigationTitle(course.name).navigationBarTitleDisplayMode(.large).toolbar {
+            }.navigationTitle(course.displayName(showEnglish: showEnglishCourseName))
+                .navigationBarTitleDisplayMode(.large).toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         dismiss()

--- a/app/dauphin/View/CourseSchedule/Shared/CourseDetailView.swift
+++ b/app/dauphin/View/CourseSchedule/Shared/CourseDetailView.swift
@@ -11,20 +11,22 @@ struct CourseDetailView: View {
     let course: Course
     @Environment(\.dismiss) var dismiss
     @AppStorage(
-        Constants.showEnglishCourseName,
-        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
-    )
-    private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
+        Constants.showEnglishCourseName, store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    ) private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
     @AppStorage(
         Constants.showEnglishTeacherName,
-        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
-    )
-    private var showEnglishTeacherName = Course.defaultShowEnglishTeacherName()
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)) private
+        var showEnglishTeacherName = Course.defaultShowEnglishTeacherName()
 
     // Cache expensive computations
     private let dayOfWeek: String
     private let timeRange: String
     private let hasNote: Bool
+
+    private var displayName: String { course.displayName(showEnglish: showEnglishCourseName) }
+    private var useCompactTitle: Bool {
+        course.isShowingEnglishName(showEnglish: showEnglishCourseName)
+    }
 
     init(course: Course) {
         self.course = course
@@ -60,8 +62,7 @@ struct CourseDetailView: View {
                     Divider()
                     detailRow(
                         title: "Instructor",
-                        content: course.displayTeacher(showEnglish: showEnglishTeacherName)
-                    )
+                        content: course.displayTeacher(showEnglish: showEnglishTeacherName))
 
                     if hasNote {
                         Divider()
@@ -76,8 +77,12 @@ struct CourseDetailView: View {
 
                 }.padding(24)
 
-            }.navigationTitle(course.displayName(showEnglish: showEnglishCourseName))
-                .navigationBarTitleDisplayMode(.large).toolbar {
+            }.navigationBarTitleDisplayMode(.inline).toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text(displayName).font(
+                        .system(size: useCompactTitle ? 15 : 17, weight: .semibold)
+                    ).lineLimit(1)
+                }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button {
                         dismiss()

--- a/app/dauphin/View/CourseSchedule/Week/CourseView.swift
+++ b/app/dauphin/View/CourseSchedule/Week/CourseView.swift
@@ -4,6 +4,11 @@ struct CourseView: View {
     let course: Course
     let height: CGFloat
     let yOffset: CGFloat
+    @AppStorage(
+        Constants.showEnglishCourseName,
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    )
+    private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
 
     var body: some View {
         RoundedRectangle(cornerRadius: 8).fill(Color(UIColor.secondarySystemBackground)).overlay(
@@ -11,9 +16,9 @@ struct CourseView: View {
         ).frame(height: height).overlay(
             VStack(alignment: .leading, spacing: 3) {
                 HStack(alignment: .top, spacing: 0) {
-                    Text(course.name).font(.system(size: 15, weight: .semibold)).foregroundColor(
-                        Color(UIColor.label)
-                    ).lineLimit(2)
+                    Text(course.displayName(showEnglish: showEnglishCourseName)).font(
+                        .system(size: 15, weight: .semibold)
+                    ).foregroundColor(Color(UIColor.label)).lineLimit(2)
                 }
 
                 HStack(spacing: 2) {

--- a/app/dauphin/View/CourseSchedule/Week/CourseView.swift
+++ b/app/dauphin/View/CourseSchedule/Week/CourseView.swift
@@ -5,10 +5,11 @@ struct CourseView: View {
     let height: CGFloat
     let yOffset: CGFloat
     @AppStorage(
-        Constants.showEnglishCourseName,
-        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
-    )
-    private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
+        Constants.showEnglishCourseName, store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    ) private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
+    private var courseNameFontSize: CGFloat {
+        course.isShowingEnglishName(showEnglish: showEnglishCourseName) ? 13 : 15
+    }
 
     var body: some View {
         RoundedRectangle(cornerRadius: 8).fill(Color(UIColor.secondarySystemBackground)).overlay(
@@ -17,7 +18,7 @@ struct CourseView: View {
             VStack(alignment: .leading, spacing: 3) {
                 HStack(alignment: .top, spacing: 0) {
                     Text(course.displayName(showEnglish: showEnglishCourseName)).font(
-                        .system(size: 15, weight: .semibold)
+                        .system(size: courseNameFontSize, weight: .semibold)
                     ).foregroundColor(Color(UIColor.label)).lineLimit(2)
                 }
 

--- a/app/dauphin/View/Setting/SettingView.swift
+++ b/app/dauphin/View/Setting/SettingView.swift
@@ -17,6 +17,16 @@ struct SettingView: View {
     @ObservedObject var viewModel: AuthViewModel
     @State private var selectedSection: SettingsSection? = .account
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @AppStorage(
+        Constants.showEnglishCourseName,
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    )
+    private var showEnglishCourseName = Course.defaultShowEnglishCourseName()
+    @AppStorage(
+        Constants.showEnglishTeacherName,
+        store: UserDefaults(suiteName: Constants.appGroupSuiteName)
+    )
+    private var showEnglishTeacherName = Course.defaultShowEnglishTeacherName()
 
     var body: some View {
         if horizontalSizeClass == .regular {
@@ -29,6 +39,15 @@ struct SettingView: View {
 
                     Section("Data Management") {
                         Label("Clear Cache", systemImage: "trash").tag(SettingsSection.cache)
+                    }
+
+                    Section("Course") {
+                        Toggle(isOn: $showEnglishCourseName) {
+                            Label("Show English Course Name", systemImage: "character.book.closed")
+                        }
+                        Toggle(isOn: $showEnglishTeacherName) {
+                            Label("Show English Teacher Name", systemImage: "person.text.rectangle")
+                        }
                     }
                 }.navigationTitle("Settings").listStyle(SidebarListStyle())
             } detail: {
@@ -61,6 +80,15 @@ struct SettingView: View {
                     Section("Data Management") {
                         NavigationLink(destination: ClearCacheView()) {
                             Label("Clear Cache", systemImage: "trash")
+                        }
+                    }
+
+                    Section("Course") {
+                        Toggle(isOn: $showEnglishCourseName) {
+                            Label("Show English Course Name", systemImage: "character.book.closed")
+                        }
+                        Toggle(isOn: $showEnglishTeacherName) {
+                            Label("Show English Teacher Name", systemImage: "person.text.rectangle")
                         }
                     }
                 }.navigationTitle("Settings")


### PR DESCRIPTION
## Summary
- redesign course domain and parsing pipeline to preserve richer API fields, stabilize IDs, normalize session/time data, and merge contiguous sessions from `cells`
- upgrade course cache to versioned payload (v2) with legacy decode fallback, and update app/widget consumers to use the new model semantics
- add settings toggles for English course/teacher names with locale-based defaults (Traditional Chinese defaults to Chinese), and apply them across schedule views and widgets

## Testing
- xcodebuild -project app/dauphin.xcodeproj -scheme dauphin -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.2' test

## Issues
- Closes #69